### PR TITLE
Reunion undocked clipboard API spec (internal team review)

### DIFF
--- a/specs/clipboard-api/clipboard-api.md
+++ b/specs/clipboard-api/clipboard-api.md
@@ -30,7 +30,7 @@ Project Reunion SDK decoupled from Windows.
 
 ### Motivation: reasons to create a new clipboard API
 
-The first version of this spec creates a new clipboard API but does not
+The first version of this spec creates a new clipboard API but _does not_
 make any changes that add substantial value. However, creating a new
 clipboard API in the Reunion SDK will let us make future improvements
 to the clipboard developer and user experiences, like these:
@@ -77,13 +77,13 @@ to the clipboard developer and user experiences, like these:
 
 * **Bring new clipboard features to all versions of Windows that support
   Project Reunion:**
-  Since the Windows clipboard has historically been considered an integrated
-  Windows component, improvements to the clipboard have only been for the
+  Since the clipboard has historically been part of the Windows OS,
+  improvements to the clipboard have only been for the
   latest Windows version. However, with the Reunion SDK, we have the
   opportunity to implement these improvements in the SDK and let all
   apps that use it benefit, and even (in some cases) apps that don't
   build against the Reunion SDK at all.
-  These features could include:
+  These features _could_ include:
 
   * _Paste as plain text_: We've seen several suggestions from
     Windows users to let you paste a formatted text fragment with all the
@@ -97,12 +97,15 @@ to the clipboard developer and user experiences, like these:
     this feature.
 
   * _Clipboard history:_ Windows 10 version 1809 (October/November 2018 update)
-    introduced a new built-in clipboard history manager. Using the same "main
+    introduced a new built-in clipboard history manager. The Project Reunion SDK
+    could allow us to bring the clipboard history manager to older Windows versions.
+    To do this, we might conceivably use the same "main
     package" as the [Project Reunion brokering system](
-    ../../docs/README.md#brokering), we could install a Windows process
-    to host the shared memory for the clipboard history, allowing us
-    to bring the APIs and user interface
-    for clipboard history to older Windows versions.
+    ../../docs/README.md#brokering) to install a Windows process
+    to host the shared memory for the clipboard history.
+    Then, the APIs and user interface for clipboard history
+    could be ported to work on that main package process
+    rather than the code shipping in Windows.
     (We could also consider using [PowerToys](
       https://github.com/microsoft/PowerToys) as the delivery vehicle
     for the clipboard history UI, while keeping the shared memory store
@@ -111,8 +114,9 @@ to the clipboard developer and user experiences, like these:
   * _Cloud clipboard sync and roaming:_ Windows 10 version 1809 also
     introduced cloud clipboard sync to other Windows devices you sign in to
     with the same personal Microsoft account or work or school Azure
-    Active Directory account. We could also use the Reunion SDK main package
-    to bring the sync client to older versions.
+    Active Directory account. Just as with clipboard history,
+    we could use use the Reunion SDK main package
+    to bring the cloud clipboard sync client to older Windows versions.
   
   * _Copy append/paste multiple_: We've also seen several suggestions from
     Windows users for a way to cut or copy multiple separate items,
@@ -125,7 +129,7 @@ to the clipboard developer and user experiences, like these:
 
 When you use Windows' built-in user interface controls, you get their
 built-in support for copying and pasting data for free. However,
-when you use your own controls or controls from a third-party vendor,
+when you make your own controls or use controls from a third-party vendor,
 you might need to implement copying and pasting yourself.
 You can do this with the clipboard API in the Project Reunion SDK.
 
@@ -151,7 +155,7 @@ except for these differences:
    app exits normally or is automatically shut down by Windows,
    as if the app called Clipboard.Flush() before exiting.
 
-## Examples
+## Example code snippets
 
 Because the Reunion SDK clipboard API is a near-copy of
 Windows.ApplicationModel.DataTransfer, these C# examples are copied from the

--- a/specs/clipboard-api/clipboard-api.md
+++ b/specs/clipboard-api/clipboard-api.md
@@ -35,7 +35,7 @@ make any changes that add substantial value. However, creating a new
 clipboard API in the Reunion SDK will let us make future improvements
 to the clipboard developer and user experiences, like these:
 
-* **Improve clipboard reliability by removing traps in the clipboard APIs:**
+* **Improve application reliability by removing traps in the clipboard APIs:**
   People encounter a lot of problems with unexpected clipboard behavior that
   they blame Windows for and that Windows could theoretically solve, even
   though the problems are typically caused by applications misusing the
@@ -58,9 +58,22 @@ to the clipboard developer and user experiences, like these:
     The Reunion SDK's new clipboard API will solve this problem by omitting
     this requirement as a caller-visible concept.
 
-  The new clipboard API could make more breaking changes to fix other
-  design errors and discourage other error-prone usage patterns
-  after a deprecation period.
+  In later version, the new clipboard API could make more changes
+  to discourage other error-prone usage patterns, such as this one:
+
+  * _Explicit ability for all apps to access clipboard in the background_:
+    In older versions of Windows, a Universal Windows Platform app could not
+    read and write the clipboard when the foreground window didn't
+    belong to that app. Newer versions of Windows don't have this
+    limitation, but this is because they allow UWP apps to have "Win32
+    full-trust" helper processes, which completely subvert the permission
+    capability system otherwise applied to UWP apps. If the Reunion SDK's
+    clipboard implementation added a background clipboard
+    access capability (as requested here: [microsoft/ProjectReunion#62](
+    https://github.com/microsoft/ProjectReunion/issues/62)),
+    then that more reliable and secure method could be made available
+    even on Windows versions where the full-trust helper workaround
+    is unavailable.
 
 * **Bring new clipboard features to all versions of Windows that support
   Project Reunion:**
@@ -119,15 +132,17 @@ You can do this with the clipboard API in the Project Reunion SDK.
 The Reunion SDK clipboard API is very similar to Windows' built-in
 clipboard API in the [Windows.ApplicationModel.DataTransfer](
 https://docs.microsoft.com/uwp/api/windows.applicationmodel.datatransfer)
-WinRT namespace. In fact, in this initial version (as of mid-2020), the Reunion
-SDK clipboard API is exactly the same as Windows.ApplicationModel.DataTransfer,
+WinRT namespace.
+In fact, in this initial version (as of mid-2020), the Reunion
+SDK clipboard API is the same as Windows.ApplicationModel.DataTransfer,
 except for these differences:
 
-1. The namespace is now Microsoft.ProjectReunion.ApplicationModel.DataTransfer.
+1. The namespace is now Microsoft.ProjectReunion.ApplicationModel.
 
-1. Types in Windows.ApplicationModel.DataTransfer that are irrelevant
-   to the clipboard are not included. For the exact set of types that are
-   included, see the [API Details section](#api-details).
+1. Types and type members in Windows.ApplicationModel.DataTransfer
+   that are irrelevant to the clipboard are not included.
+   For the exact set of types that are included, see the
+   [API Notes section](#api-notes).
 
 1. Your app will no longer ever need to call [Clipboard.Flush()](
    https://docs.microsoft.com/uwp/api/windows.applicationmodel.datatransfer.clipboard.flush)
@@ -140,13 +155,13 @@ except for these differences:
 
 Because the Reunion SDK clipboard API is a near-copy of
 Windows.ApplicationModel.DataTransfer, these C# examples are copied from the
-guide to coding copy and paste in a Universal Windows Platform app using
-Windows.ApplicationModel.DataTransfer:
-https://docs.microsoft.com/windows/uwp/app-to-app/copy-and-paste
+[guide to coding copy and paste in a UWP app](
+https://docs.microsoft.com/windows/uwp/app-to-app/copy-and-paste)
+using Windows.ApplicationModel.DataTransfer.
 
 ### Get set up to access the clipboard
 
-First, include the **Microsoft.ProjectReunion.ApplicationModel.DataTransfer**
+First, include the **Microsoft.ProjectReunion.ApplicationModel**
 namespace in your app. Then, create an instance of the **DataPackage** class.
 This object contains both the data the user wants to copy and any properties
 (such as a description) that you want to include.
@@ -239,9 +254,11 @@ Clipboard.ContentChanged += async (s, e) =>
 ## API Details
 
 The syntactic interface of the Project Reunion SDK's clipboard API
-is an exact subset of [Windows.ApplicationModel.DataTransfer](
-https://docs.microsoft.com/uwp/api/windows.applicationmodel.datatransfer),
-apart from a different name (Microsoft.ProjectReunion.ApplicationModel.DataTransfer).
+is a subset of [Windows.ApplicationModel.DataTransfer](
+https://docs.microsoft.com/uwp/api/windows.applicationmodel.datatransfer)
+with a different name (Microsoft.ProjectReunion.ApplicationModel).
+Certain types (classes and enums) are omitted, and certain classes
+may have omitted members that are not relevant to clipboard usage.
 
 The set of types from Windows.ApplicationModel.DataTransfer that
 will be copied into the clipboard API is the following:

--- a/specs/clipboard-api/clipboard-api.md
+++ b/specs/clipboard-api/clipboard-api.md
@@ -50,7 +50,13 @@ to the clipboard developer and user experiences, like these:
     CloseClipboard(). The new clipboard API in the Reunion SDK will solve
     this problem by omitting the clipboard lock as a caller-visible concept.
 
-  * _No need to flush clipboard_: Sometimes, a cut or copied data value is lost and the clipboard is cleared when the source app exits or crashes. This is likely to happen for clipboard source apps that use the OLE data transfer API or Windows.ApplicationModel.DataTransfer, since those APIs require an explicit "flush clipboard" call to make data set on clipboard persist after the source app exits. The Reunion SDK's new clipboard API will solve this problem by omitting this requirement as a caller-visible concept.
+  * _No need to flush clipboard_: Sometimes, a cut or copied data value is lost
+    and the clipboard is cleared when the source app exits or crashes.
+    This is likely to happen for clipboard source apps that use the OLE data transfer API
+    or Windows.ApplicationModel.DataTransfer, since those APIs require an explicit
+    "flush clipboard" call to make data set on clipboard persist after the source app exits.
+    The Reunion SDK's new clipboard API will solve this problem by omitting
+    this requirement as a caller-visible concept.
 
   The new clipboard API could make more breaking changes to fix other
   design errors and discourage other error-prone usage patterns
@@ -111,8 +117,9 @@ you might need to implement copying and pasting yourself.
 You can do this with the clipboard API in the Project Reunion SDK.
 
 The Reunion SDK clipboard API is very similar to Windows' built-in
-clipboard API in the Windows.ApplicationModel.DataTransfer WinRT namespace.
-In fact, in this initial version (as of mid-2020), the Reunion
+clipboard API in the [Windows.ApplicationModel.DataTransfer](
+https://docs.microsoft.com/uwp/api/windows.applicationmodel.datatransfer)
+WinRT namespace. In fact, in this initial version (as of mid-2020), the Reunion
 SDK clipboard API is exactly the same as Windows.ApplicationModel.DataTransfer,
 except for these differences:
 
@@ -123,16 +130,16 @@ except for these differences:
    included, see the [API Details section](#api-details).
 
 1. Your app will no longer ever need to call [Clipboard.Flush()](
-  https://docs.microsoft.com/uwp/api/windows.applicationmodel.datatransfer.clipboard.flush)
-  after setting the clipboard data on cut or copy. All formats for the
-  clipboard data item set by your app will be available after your
-  app exits normally or is automatically shut down by Windows,
-  as if the app called Clipboard.Flush() before exiting.
+   https://docs.microsoft.com/uwp/api/windows.applicationmodel.datatransfer.clipboard.flush)
+   after setting the clipboard data on cut or copy. All formats for the
+   clipboard data item set by your app will be available after your
+   app exits normally or is automatically shut down by Windows,
+   as if the app called Clipboard.Flush() before exiting.
 
 ## Examples
 
 Because the Reunion SDK clipboard API is a near-copy of
-Windows.ApplicationModel.DataTransfer, these examples are copied from the
+Windows.ApplicationModel.DataTransfer, these C# examples are copied from the
 guide to coding copy and paste in a Universal Windows Platform app using
 Windows.ApplicationModel.DataTransfer:
 https://docs.microsoft.com/windows/uwp/app-to-app/copy-and-paste
@@ -239,7 +246,8 @@ apart from a different name (Microsoft.ProjectReunion.ApplicationModel.DataTrans
 The set of types from Windows.ApplicationModel.DataTransfer that
 will be copied into the clipboard API is the following:
 
-* `Clipboard` - Top level for the clipboard API. Provides "static" methods
+* [`Clipboard`](https://docs.microsoft.com/uwp/api/windows.applicationmodel.datatransfer.clipboard) -
+  Top level for the clipboard API. Provides "static" methods
   (methods implemented by the class's activation factory) to read and write
   the current clipboard item and clipboard history, along with methods
   to read settings for clipboard history and cloud clipboard sync.
@@ -253,7 +261,8 @@ will be copied into the clipboard API is the following:
   * `OperationCompletedEventArgs`
   * `SetHistoryItemAsContentStatus`
 
-* `DataPackage` - Unit of data transfer for the clipboard API.
+* [`DataPackage`](https://docs.microsoft.com/uwp/api/windows.applicationmodel.datatransfer.datapackage) -
+  Unit of data transfer for the clipboard API.
 
 * `DataPackage`-related types:
   * `DataPackageView`
@@ -272,9 +281,11 @@ will be copied into the clipboard API is the following:
 
 Initially, the implementation of the Project Reunion SDK's clipboard APi
 will be a set of very thin wrappers around the same-named codes in
-Windows.ApplicationModel.DataTransfer.
+[Windows.ApplicationModel.DataTransfer](
+https://docs.microsoft.com/uwp/api/windows.applicationmodel.datatransfer).
 
-The only exception will be the change to make Clipboard.Flush()
+The only exception will be the change to make [Clipboard.Flush()](
+https://docs.microsoft.com/uwp/api/windows.applicationmodel.datatransfer.clipboard.flush)
 a completely optional operation.
 (TO CONSIDER: Should Clipboard.Flush() be removed entirely?)
 This will be implemented by Clipboard.SetContent(), which will register
@@ -293,7 +304,9 @@ to exit or be suspended:
   otherwise.
 
 * For other apps, a worker thread will initialize COM in STA
-  and create a message-only user32.dll window, whose window procedure
-  handles WM_DESTROY by calling Clipboard.Flush(). When the application
-  exits normally, the window will receive WM_DESTROY.
-
+  and create a [message-only user32.dll window](
+  https://docs.microsoft.com/windows/win32/winmsg/window-features#message-only-windows),
+  whose window procedure handles [WM_DESTROY](
+  https://docs.microsoft.com/windows/win32/winmsg/wm-destroy)
+  by calling Clipboard.Flush(). When the application exits normally,
+  the window will receive WM_DESTROY.

--- a/specs/clipboard-api/clipboard-api.md
+++ b/specs/clipboard-api/clipboard-api.md
@@ -5,28 +5,28 @@
 The Windows clipboard is the component that's responsible for implementing
 the "cut", "copy", and "paste" system for moving and copying data from one
 Windows application to another. Windows maintains one clipboard per
-interactively signed-in user (more precisely, one clipboard per Remote Desktop/
-Terminal Services session), which can hold any number of data "formats"
-which are all intended to represent the same data value.
+user currently signed in to the computer. The current clipboard data consists
+of one or more different representations, called "clipboard formats",
+of what the user would consider as the same data value.
 
 This specification defines the API for the Windows clipboard within the
-Project Reunion SDK. This Windows Runtime API is a [converged API interface](
+Project Reunion SDK. This API is a [converged API interface](
   ../../docs/README.md#converged-apis) in the Project Reunion SDK,
-which is intended to replace the following 3 clipboard APIs within Windows:
+which is intended to consolidate the following 3 clipboard APIs within Windows:
 
-* [The classic clipboard API](https://docs.microsoft.com/windows/win32/dataxchg/clipboard),
-  including GetClipboardData() and friends in windows.h.
+* [The classic clipboard API](https://docs.microsoft.com/windows/win32/dataxchg/clipboard)
+  ("Win32 clipboard"), including GetClipboardData() and friends in windows.h.
 
 * [The OLE data transfer API](https://docs.microsoft.com/windows/win32/com/data-transfer),
   including OleGetClipboard() and friends in ole2.h.
 
 * [Windows.ApplicationModel.DataTransfer.Clipboard](https://docs.microsoft.com/windows/uwp/app-to-app/copy-and-paste)
-  and friends.
+  and friends ("UWP clipboard").
 
-Although this API will be based closely on Windows.ApplicationModel.DataTransfer,
+Although this API will be based closely on "UWP clipboard" in
+Windows.ApplicationModel.DataTransfer,
 its implementation will be delivered as an open-source part of the
-Project Reunion SDK decoupled from Windows. It will _not_ be added to Windows
-as part of the [Reunion Subset API Family](../../docs/README.md#subset-api-family).
+Project Reunion SDK decoupled from Windows.
 
 ### Motivation: reasons to create a new clipboard API
 
@@ -39,10 +39,10 @@ to the clipboard developer and user experiences, like these:
   People encounter a lot of problems with unexpected clipboard behavior that
   they blame Windows for and that Windows could theoretically solve, even
   though the problems are typically caused by applications misusing the
-  clipboard. The new clipboard API makes breaking changes from the previous
-  APIs that solve some of these problems:
+  clipboard. Here are some of these problems, along with how the new
+  clipboard API solves them by making breaking changes from the previous APIs:
 
-  * _No clipboard lock_: Often, attempts to cut or copy data are seemingly
+  * _No Win32 clipboard lock_: Often, attempts to cut or copy data are seemingly
     ignored - the previous data value on the clipboard gets pasted instead,
     if there was one. This can happen when the previous source app uses the
     classic clipboard API, since apps using that API obtain a lock on the
@@ -50,7 +50,7 @@ to the clipboard developer and user experiences, like these:
     CloseClipboard(). The new clipboard API in the Reunion SDK will solve
     this problem by omitting the clipboard lock as a caller-visible concept.
 
-  * _No need to flush clipboard_: Sometimes, a cut or copied data value is lost
+  * _No need to flush OLE and UWP clipboard_: Sometimes, a cut or copied data value is lost
     and the clipboard is cleared when the source app exits or crashes.
     This is likely to happen for clipboard source apps that use the OLE data transfer API
     or Windows.ApplicationModel.DataTransfer, since those APIs require an explicit
@@ -130,9 +130,9 @@ you might need to implement copying and pasting yourself.
 You can do this with the clipboard API in the Project Reunion SDK.
 
 The Reunion SDK clipboard API is very similar to Windows' built-in
-clipboard API in the [Windows.ApplicationModel.DataTransfer](
+"UWP clipboard" API in the [Windows.ApplicationModel.DataTransfer](
 https://docs.microsoft.com/uwp/api/windows.applicationmodel.datatransfer)
-WinRT namespace.
+Windows Runtime namespace.
 In fact, in this initial version (as of mid-2020), the Reunion
 SDK clipboard API is the same as Windows.ApplicationModel.DataTransfer,
 except for these differences:

--- a/specs/clipboard-api/clipboard-api.md
+++ b/specs/clipboard-api/clipboard-api.md
@@ -1,0 +1,235 @@
+# Decoupled API for Windows clipboard in Project Reunion SDK
+
+## Background
+
+The Windows clipboard is the component that's responsible for implementing
+the "cut", "copy", and "paste" system for moving and copying data from one
+Windows application to another. Windows maintains one clipboard per
+interactively signed-in user (more precisely, one clipboard per Remote Desktop/
+Terminal Services session), which can hold any number of data "formats"
+which are all intended to represent the same data value.
+
+This specification defines the API for the Windows clipboard within the
+Project Reunion SDK. This Windows Runtime API is a [converged API interface](
+  ../../docs/README.md#converged-apis) in the Project Reunion SDK,
+which is intended to replace the following 3 clipboard APIs within Windows:
+
+* [The classic clipboard API](https://docs.microsoft.com/windows/win32/dataxchg/clipboard),
+  including GetClipboardData() and friends in windows.h.
+
+* [The OLE data transfer API](https://docs.microsoft.com/windows/win32/com/data-transfer),
+  including OleGetClipboard() and friends in ole2.h.
+
+* [Windows.ApplicationModel.DataTransfer.Clipboard](https://docs.microsoft.com/windows/uwp/app-to-app/copy-and-paste)
+  and friends.
+
+Although this API will be based closely on Windows.ApplicationModel.DataTransfer,
+its implementation will be delivered as an open-source part of the
+Project Reunion SDK decoupled from Windows. It will _not_ be added to Windows
+as part of the [Reunion Subset API Family](../../docs/README.md#subset-api-family).
+
+### Motivation: reasons to create a new clipboard API
+
+The first version of this spec creates a new clipboard API but does not
+make any changes that add substantial value. However, creating a new
+clipboard API in the Reunion SDK will let us make future improvements
+to the clipboard developer and user experiences, like these:
+
+* **Improve clipboard reliability by removing traps in the clipboard APIs:**
+  People encounter a lot of problems with unexpected clipboard behavior that
+  they blame Windows for and that Windows could theoretically solve, even
+  though the problems are typically caused by applications misusing the
+  clipboard. The new clipboard API makes breaking changes from the previous
+  APIs that solve some of these problems:
+
+  * _No clipboard lock_: Often, attempts to cut or copy data are seemingly
+    ignored - the previous data value on the clipboard gets pasted instead,
+    if there was one. This can happen when the previous source app uses the
+    classic clipboard API, since apps using that API obtain a lock on the
+    clipboard with OpenClipboard() that they must manually release with
+    CloseClipboard(). The new clipboard API in the Reunion SDK will solve
+    this problem by omitting the clipboard lock as a caller-visible concept.
+
+  * _No need to flush clipboard_: Sometimes, a cut or copied data value is lost and the clipboard is cleared when the source app exits or crashes. This is likely to happen for clipboard source apps that use the OLE data transfer API or Windows.ApplicationModel.DataTransfer, since those APIs require an explicit "flush clipboard" call to make data set on clipboard persist after the source app exits. The Reunion SDK's new clipboard API will solve this problem by omitting this requirement as a caller-visible concept.
+
+  The new clipboard API could make more breaking changes to fix other
+  design errors and discourage other error-prone usage patterns
+  after a deprecation period.
+
+* **Bring new clipboard features to all versions of Windows that support
+  Project Reunion:**
+  Since the Windows clipboard has historically been considered an integrated
+  Windows component, improvements to the clipboard have only been for the
+  latest Windows version. However, with the Reunion SDK, we have the
+  opportunity to implement these improvements in the SDK and let all
+  apps that use it benefit, and even (in some cases) apps that don't
+  build against the Reunion SDK at all.
+  These features could include:
+
+  * _Paste as plain text_: We've seen several suggestions from
+    Windows users to let you paste a formatted text fragment with all the
+    formatting stripped out. Many applications let you do this, but some
+    don't, especially when the app from which the formatted text was cut
+    or copied only provides the formatted version to the clipboard APIs.
+    We could implement a "to plain text" feature to automatically create
+    plain text from formatted HTML or RTF text when needed on either cut/copy
+    or paste, then update the edit controls in Microsoft.UI.Xaml
+    to use the Reunion clipboard API and therefore take advantage of
+    this feature.
+
+  * _Clipboard history:_ Windows 10 version 1809 (October/November 2018 update)
+    introduced a new built-in clipboard history manager. Using the same "main
+    package" as the [Project Reunion brokering system](
+    ../../docs/README.md#brokering), we could install a Windows process
+    to host the shared memory for the clipboard history, allowing us
+    to bring the APIs and user interface
+    for clipboard history to older Windows versions.
+    (We could also consider using [PowerToys](
+      https://github.com/microsoft/PowerToys) as the delivery vehicle
+    for the clipboard history UI, while keeping the shared memory store
+    and API implementations as part of the Reunion SDK.)
+  
+  * _Cloud clipboard sync and roaming:_ Windows 10 version 1809 also
+    introduced cloud clipboard sync to other Windows devices you sign in to
+    with the same personal Microsoft account or work or school Azure
+    Active Directory account. We could also use the Reunion SDK main package
+    to bring the sync client to older versions.
+  
+  * _Copy append/paste multiple_: We've also seen several suggestions from
+    Windows users for a way to cut or copy multiple separate items,
+    then paste them all at once in the same order that they were
+    originally cut or copied. If we did implement this feature,
+    we could put its memory store in the Reunion SDK main package
+    to bring it to older Windows releases.
+
+## Description
+
+When you use Windows' built-in user interface controls, you get their built-in support for copying and pasting data for free. However, when you use your own controls or controls from a third-party vendor, you might need to implement copying and pasting yourself. You can do this with the clipboard API in the Project Reunion SDK, 
+
+T, described in the examples of this document, is very similar to those of Windows.ApplicationModel.DataTransfer, with only 2 differences. We'll call out these differences in the following examples. For the rest of the information, start here to refer to the existing documentation: https://docs.microsoft.com/windows/uwp/app-to-app/copy-and-paste
+
+## Examples
+
+### Get set up to access the clipboard
+
+First, include the [**Windows.ApplicationModel.DataTransfer**](https://docs.microsoft.com/uwp/api/Windows.ApplicationModel.DataTransfer) namespace in your app. Then, add an instance of the [**DataPackage**](https://docs.microsoft.com/uwp/api/Windows.ApplicationModel.DataTransfer.DataPackage) object. This object contains both the data the user wants to copy and any properties (such as a description) that you want to include.
+
+```csharp
+DataPackage dataPackage = new DataPackage();
+```
+
+### Copy and cut
+
+Copy and cut (also referred to as *move*) work almost exactly the same. Choose which operation you want by using the [**RequestedOperation**](https://docs.microsoft.com/uwp/api/windows.applicationmodel.datatransfer.datapackage.requestedoperation) property.
+
+```csharp
+// copy
+dataPackage.RequestedOperation = DataPackageOperation.Copy;
+// or cut
+dataPackage.RequestedOperation = DataPackageOperation.Move;
+```
+
+### Set the copied content
+
+Next, you can add the data that a user has selected to the [**DataPackage**](https://docs.microsoft.com/uwp/api/Windows.ApplicationModel.DataTransfer.DataPackage) object. If this data is supported by the **DataPackage** class, you can use one of the corresponding [methods](https://docs.microsoft.com/uwp/api/windows.applicationmodel.datatransfer.datapackage#methods) of the **DataPackage** object. Here's how to add text by using the [**SetText**](https://docs.microsoft.com/uwp/api/windows.applicationmodel.datatransfer.datapackage.settext) method:
+
+```csharp
+dataPackage.SetText("Hello World!");
+```
+
+The last step is to add the [**DataPackage**](https://docs.microsoft.com/uwp/api/Windows.ApplicationModel.DataTransfer.DataPackage) to the clipboard by calling the static [**SetContent**](https://docs.microsoft.com/uwp/api/windows.applicationmodel.datatransfer.clipboard.setcontent) method.
+
+```csharp
+Clipboard.SetContent(dataPackage);
+```
+
+### Paste
+
+To get the contents of the clipboard, call the static [**GetContent**](https://docs.microsoft.com/uwp/api/windows.applicationmodel.datatransfer.clipboard.getcontent) method. This method returns a [**DataPackageView**](https://docs.microsoft.com/uwp/api/Windows.ApplicationModel.DataTransfer.DataPackageView) that contains the content. This object is almost identical to a [**DataPackage**](https://docs.microsoft.com/uwp/api/Windows.ApplicationModel.DataTransfer.DataPackage) object, except that its contents are read-only. With that object, you can use either the [**AvailableFormats**](https://docs.microsoft.com/uwp/api/windows.applicationmodel.datatransfer.datapackageview.availableformats) or the [**Contains**](https://docs.microsoft.com/uwp/api/windows.applicationmodel.datatransfer.datapackageview.contains) method to identify what formats are available. Then, you can call the corresponding [**DataPackageView**](https://docs.microsoft.com/uwp/api/Windows.ApplicationModel.DataTransfer.DataPackageView) method to get the data.
+
+```csharp
+async void OutputClipboardText()
+{
+    DataPackageView dataPackageView = Clipboard.GetContent();
+    if (dataPackageView.Contains(StandardDataFormats.Text))
+    {
+        string text = await dataPackageView.GetTextAsync();
+        // To output the text from this example, you need a TextBlock control
+        TextOutput.Text = "Clipboard now contains: " + text;
+    }
+}
+```
+
+### Track changes to the clipboard
+
+In addition to copy and paste commands, you may also want to track clipboard changes. Do this by handling the clipboard's [**ContentChanged**](https://docs.microsoft.com/uwp/api/windows.applicationmodel.datatransfer.clipboard.contentchanged) event.
+
+```csharp
+Clipboard.ContentChanged += async (s, e) => 
+{
+    DataPackageView dataPackageView = Clipboard.GetContent();
+    if (dataPackageView.Contains(StandardDataFormats.Text))
+    {
+        string text = await dataPackageView.GetTextAsync();
+        // To output the text from this example, you need a TextBlock control
+        TextOutput.Text = "Clipboard now contains: " + text;
+    }
+}
+```
+
+## Remarks
+
+<!-- TEMPLATE
+    Explanation and guidance that doesn't fit into the Examples section.
+    APIs should only throw exceptions in exceptional conditions; basically,
+    only when there's a bug in the caller, such as argument exception.  But if for some
+    reason it's necessary for a caller to catch an exception from an API, call that
+    out with an explanation either here or in the Examples
+-->
+
+## API Notes
+
+<!-- TEMPLATE
+    Option 1: Give a one or two line description of each API (type and member),
+        or at least the ones that aren't obvious from their name. These
+        descriptions are what show up in IntelliSense. For properties, specify
+        the default value of the property if it isn't the type's default (for
+        example an int-typed property that doesn't default to zero.) 
+        
+    Option 2: Put these descriptions in the below API Details section,
+        with a "///" comment above the member or type. 
+-->
+
+## API Details
+
+<!-- TEMPLATE
+    The exact API, in MIDL3 format (https://docs.microsoft.com/en-us/uwp/midl-3/)
+    when possible, or in C# if starting with an API sketch.  GitHub's markdown
+    syntax formatter does not (yet) know about MIDL3, so use ```c# instead even
+    when writing MIDL3.
+    Example:
+    ```c# (but really MIDL3)
+    namespace Microsoft.AppModel
+    {
+        /// Represents a package on the host system. See Windows.ApplicationModel.Package for more details
+        runtimeclass Package
+        {
+            /// Returns the current package, or null if the current process is not packaged
+            static Package Current { get; };
+            /// Returns the package from the system store with this full name or null if not found
+            static Package GetFromFullName(String fullName);
+            /// Returns packages in the given family, by name
+            static Package[] FindByFamilyName(String familyName);
+        }
+    }
+    ```
+-->
+
+## Appendix
+
+<!-- TEMPLATE
+    Anything else that you want to write down for posterity, but
+    that isn't necessary to understand the purpose and usage of the API.
+    For example, implementation details.
+    
+-->

--- a/specs/clipboard-api/clipboard-api.md
+++ b/specs/clipboard-api/clipboard-api.md
@@ -249,16 +249,12 @@ Clipboard.ContentChanged += async (s, e) =>
 
 ## API Notes
 
-\[To be added\]
-
-## API Details
-
 The syntactic interface of the Project Reunion SDK's clipboard API
 is a subset of [Windows.ApplicationModel.DataTransfer](
 https://docs.microsoft.com/uwp/api/windows.applicationmodel.datatransfer)
 with a different name (Microsoft.ProjectReunion.ApplicationModel).
-Certain types (classes and enums) are omitted, and certain classes
-may have omitted members that are not relevant to clipboard usage.
+Certain types (classes and enums) are omitted, and one class, `DataPackage`,
+omits 2 members that are not relevant to clipboard usage.
 
 The set of types from Windows.ApplicationModel.DataTransfer that
 will be copied into the clipboard API is the following:
@@ -280,6 +276,7 @@ will be copied into the clipboard API is the following:
 
 * [`DataPackage`](https://docs.microsoft.com/uwp/api/windows.applicationmodel.datatransfer.datapackage) -
   Unit of data transfer for the clipboard API.
+  The `ShareCompleted` and `ShareCanceled` events are omitted.
 
 * `DataPackage`-related types:
   * `DataPackageView`
@@ -292,14 +289,21 @@ will be copied into the clipboard API is the following:
   * `HtmlFormatHelper`
   * `StandardDataFormats`
 
-\[To be expanded with IDL\]
+## API Details
+
+See [`clipboard.idl`](clipboard.idl) for a complete [MIDL 3.0](
+https://docs.microsoft.com/uwp/midl-3/) description
+of the Project Reunion SDK's clipboard API.
 
 ## Appendix
 
 Initially, the implementation of the Project Reunion SDK's clipboard APi
 will be a set of very thin wrappers around the same-named codes in
 [Windows.ApplicationModel.DataTransfer](
-https://docs.microsoft.com/uwp/api/windows.applicationmodel.datatransfer).
+https://docs.microsoft.com/uwp/api/windows.applicationmodel.datatransfer),
+which will gracefully fail with E_NOTIMPL or similar for features that
+are not implemented on that Windows version. (This will be mostly limited
+to cloud clipboard roaming and clipboard history.)
 
 The only exception will be the change to make [Clipboard.Flush()](
 https://docs.microsoft.com/uwp/api/windows.applicationmodel.datatransfer.clipboard.flush)

--- a/specs/clipboard-api/clipboard-api.md
+++ b/specs/clipboard-api/clipboard-api.md
@@ -232,8 +232,9 @@ Clipboard.ContentChanged += async (s, e) =>
 ## API Details
 
 The syntactic interface of the Project Reunion SDK's clipboard API
-is an exact subset of Windows.ApplicationModel.DataTransfer, apart
-from a different name (Microsoft.ProjectReunion.ApplicationModel.DataTransfer).
+is an exact subset of [Windows.ApplicationModel.DataTransfer](
+https://docs.microsoft.com/uwp/api/windows.applicationmodel.datatransfer),
+apart from a different name (Microsoft.ProjectReunion.ApplicationModel.DataTransfer).
 
 The set of types from Windows.ApplicationModel.DataTransfer that
 will be copied into the clipboard API is the following:

--- a/specs/clipboard-api/clipboard-api.md
+++ b/specs/clipboard-api/clipboard-api.md
@@ -270,9 +270,9 @@ will be copied into the clipboard API is the following:
   * `ClipboardHistoryItem`
   * `ClipboardHistoryItemsResult`
   * `ClipboardHistoryItemsResultStatus`
-  * `ClipboardHistoryChangedEventArgs`
   * `OperationCompletedEventArgs`
   * `SetHistoryItemAsContentStatus`
+  * (`ClipboardHistoryChangedEventArgs` is omitted because it's an empty class.)
 
 * [`DataPackage`](https://docs.microsoft.com/uwp/api/windows.applicationmodel.datatransfer.datapackage) -
   Unit of data transfer for the clipboard API.

--- a/specs/clipboard-api/clipboard-api.md
+++ b/specs/clipboard-api/clipboard-api.md
@@ -104,15 +104,45 @@ to the clipboard developer and user experiences, like these:
 
 ## Description
 
-When you use Windows' built-in user interface controls, you get their built-in support for copying and pasting data for free. However, when you use your own controls or controls from a third-party vendor, you might need to implement copying and pasting yourself. You can do this with the clipboard API in the Project Reunion SDK, 
+When you use Windows' built-in user interface controls, you get their
+built-in support for copying and pasting data for free. However,
+when you use your own controls or controls from a third-party vendor,
+you might need to implement copying and pasting yourself.
+You can do this with the clipboard API in the Project Reunion SDK.
 
-T, described in the examples of this document, is very similar to those of Windows.ApplicationModel.DataTransfer, with only 2 differences. We'll call out these differences in the following examples. For the rest of the information, start here to refer to the existing documentation: https://docs.microsoft.com/windows/uwp/app-to-app/copy-and-paste
+The Reunion SDK clipboard API is very similar to Windows' built-in
+clipboard API in the Windows.ApplicationModel.DataTransfer WinRT namespace.
+In fact, in this initial version (as of mid-2020), the Reunion
+SDK clipboard API is exactly the same as Windows.ApplicationModel.DataTransfer,
+except for these differences:
+
+1. The namespace is now Microsoft.ProjectReunion.ApplicationModel.DataTransfer.
+
+1. Types in Windows.ApplicationModel.DataTransfer that are irrelevant
+   to the clipboard are not included. For the exact set of types that are
+   included, see the [API Details section](#api-details).
+
+1. Your app will no longer ever need to call [Clipboard.Flush()](
+  https://docs.microsoft.com/uwp/api/windows.applicationmodel.datatransfer.clipboard.flush)
+  after setting the clipboard data on cut or copy. All formats for the
+  clipboard data item set by your app will be available after your
+  app exits normally or is automatically shut down by Windows,
+  as if the app called Clipboard.Flush() before exiting.
 
 ## Examples
 
+Because the Reunion SDK clipboard API is a near-copy of
+Windows.ApplicationModel.DataTransfer, these examples are copied from the
+guide to coding copy and paste in a Universal Windows Platform app using
+Windows.ApplicationModel.DataTransfer:
+https://docs.microsoft.com/windows/uwp/app-to-app/copy-and-paste
+
 ### Get set up to access the clipboard
 
-First, include the [**Windows.ApplicationModel.DataTransfer**](https://docs.microsoft.com/uwp/api/Windows.ApplicationModel.DataTransfer) namespace in your app. Then, add an instance of the [**DataPackage**](https://docs.microsoft.com/uwp/api/Windows.ApplicationModel.DataTransfer.DataPackage) object. This object contains both the data the user wants to copy and any properties (such as a description) that you want to include.
+First, include the **Microsoft.ProjectReunion.ApplicationModel.DataTransfer**
+namespace in your app. Then, create an instance of the **DataPackage** class.
+This object contains both the data the user wants to copy and any properties
+(such as a description) that you want to include.
 
 ```csharp
 DataPackage dataPackage = new DataPackage();
@@ -120,7 +150,9 @@ DataPackage dataPackage = new DataPackage();
 
 ### Copy and cut
 
-Copy and cut (also referred to as *move*) work almost exactly the same. Choose which operation you want by using the [**RequestedOperation**](https://docs.microsoft.com/uwp/api/windows.applicationmodel.datatransfer.datapackage.requestedoperation) property.
+Copy and cut (also referred to as *move*) work almost exactly the same.
+Choose which operation you want by using the **RequestedOperation** property
+of **DataPackage**.
 
 ```csharp
 // copy
@@ -131,13 +163,17 @@ dataPackage.RequestedOperation = DataPackageOperation.Move;
 
 ### Set the copied content
 
-Next, you can add the data that a user has selected to the [**DataPackage**](https://docs.microsoft.com/uwp/api/Windows.ApplicationModel.DataTransfer.DataPackage) object. If this data is supported by the **DataPackage** class, you can use one of the corresponding [methods](https://docs.microsoft.com/uwp/api/windows.applicationmodel.datatransfer.datapackage#methods) of the **DataPackage** object. Here's how to add text by using the [**SetText**](https://docs.microsoft.com/uwp/api/windows.applicationmodel.datatransfer.datapackage.settext) method:
+Next, you can add the data value that a user has selected to the **DataPackage**
+object. If all formats for this data value are supported by the **DataPackage**
+class, you can use one of **DataPackage**'s corresponding methods.
+Here's how to add text by using the **SetText** method:
 
 ```csharp
 dataPackage.SetText("Hello World!");
 ```
 
-The last step is to add the [**DataPackage**](https://docs.microsoft.com/uwp/api/Windows.ApplicationModel.DataTransfer.DataPackage) to the clipboard by calling the static [**SetContent**](https://docs.microsoft.com/uwp/api/windows.applicationmodel.datatransfer.clipboard.setcontent) method.
+The last step is to add the **DataPackage** to the clipboard by calling the
+static **Clipboard.SetContent** method.
 
 ```csharp
 Clipboard.SetContent(dataPackage);
@@ -145,91 +181,118 @@ Clipboard.SetContent(dataPackage);
 
 ### Paste
 
-To get the contents of the clipboard, call the static [**GetContent**](https://docs.microsoft.com/uwp/api/windows.applicationmodel.datatransfer.clipboard.getcontent) method. This method returns a [**DataPackageView**](https://docs.microsoft.com/uwp/api/Windows.ApplicationModel.DataTransfer.DataPackageView) that contains the content. This object is almost identical to a [**DataPackage**](https://docs.microsoft.com/uwp/api/Windows.ApplicationModel.DataTransfer.DataPackage) object, except that its contents are read-only. With that object, you can use either the [**AvailableFormats**](https://docs.microsoft.com/uwp/api/windows.applicationmodel.datatransfer.datapackageview.availableformats) or the [**Contains**](https://docs.microsoft.com/uwp/api/windows.applicationmodel.datatransfer.datapackageview.contains) method to identify what formats are available. Then, you can call the corresponding [**DataPackageView**](https://docs.microsoft.com/uwp/api/Windows.ApplicationModel.DataTransfer.DataPackageView) method to get the data.
+To get the data value currently on the clipboard, call the static
+**Clipboard.GetContent** method. This method returns a **DataPackageView**
+that contains the current clipboard data value. This object is almost
+identical to a **DataPackage** object, except that its contents are read-only.
+With a **DataPackageView** object, you can use either the **AvailableFormats**
+property or the **Contains** method to identify what formats are available.
+Then, you can call the corresponding **DataPackageView** method to get the
+data in the format or formats your app needs.
 
 ```csharp
 async void OutputClipboardText()
 {
-    DataPackageView dataPackageView = Clipboard.GetContent();
-    if (dataPackageView.Contains(StandardDataFormats.Text))
-    {
-        string text = await dataPackageView.GetTextAsync();
-        // To output the text from this example, you need a TextBlock control
-        TextOutput.Text = "Clipboard now contains: " + text;
-    }
+  DataPackageView dataPackageView = Clipboard.GetContent();
+  if (dataPackageView.Contains(StandardDataFormats.Text))
+  {
+    string text = await dataPackageView.GetTextAsync();
+    // To output the text from this example, you need a TextBlock control
+    TextOutput.Text = "Clipboard now contains: " + text;
+  }
 }
 ```
 
 ### Track changes to the clipboard
 
-In addition to copy and paste commands, you may also want to track clipboard changes. Do this by handling the clipboard's [**ContentChanged**](https://docs.microsoft.com/uwp/api/windows.applicationmodel.datatransfer.clipboard.contentchanged) event.
+In addition to copy and paste commands, you may also want to track clipboard
+changes. Do this by handling the clipboard's **ContentChanged** event.
 
 ```csharp
-Clipboard.ContentChanged += async (s, e) => 
+Clipboard.ContentChanged += async (s, e) =>
 {
-    DataPackageView dataPackageView = Clipboard.GetContent();
-    if (dataPackageView.Contains(StandardDataFormats.Text))
-    {
-        string text = await dataPackageView.GetTextAsync();
-        // To output the text from this example, you need a TextBlock control
-        TextOutput.Text = "Clipboard now contains: " + text;
-    }
+  DataPackageView dataPackageView = Clipboard.GetContent();
+  if (dataPackageView.Contains(StandardDataFormats.Text))
+  {
+    string text = await dataPackageView.GetTextAsync();
+    // To output the text from this example, you need a TextBlock control
+    TextOutput.Text = "Clipboard now contains: " + text;
+  }
 }
 ```
 
 ## Remarks
 
-<!-- TEMPLATE
-    Explanation and guidance that doesn't fit into the Examples section.
-    APIs should only throw exceptions in exceptional conditions; basically,
-    only when there's a bug in the caller, such as argument exception.  But if for some
-    reason it's necessary for a caller to catch an exception from an API, call that
-    out with an explanation either here or in the Examples
--->
+\[None at this time\]
 
 ## API Notes
 
-<!-- TEMPLATE
-    Option 1: Give a one or two line description of each API (type and member),
-        or at least the ones that aren't obvious from their name. These
-        descriptions are what show up in IntelliSense. For properties, specify
-        the default value of the property if it isn't the type's default (for
-        example an int-typed property that doesn't default to zero.) 
-        
-    Option 2: Put these descriptions in the below API Details section,
-        with a "///" comment above the member or type. 
--->
+\[To be added\]
 
 ## API Details
 
-<!-- TEMPLATE
-    The exact API, in MIDL3 format (https://docs.microsoft.com/en-us/uwp/midl-3/)
-    when possible, or in C# if starting with an API sketch.  GitHub's markdown
-    syntax formatter does not (yet) know about MIDL3, so use ```c# instead even
-    when writing MIDL3.
-    Example:
-    ```c# (but really MIDL3)
-    namespace Microsoft.AppModel
-    {
-        /// Represents a package on the host system. See Windows.ApplicationModel.Package for more details
-        runtimeclass Package
-        {
-            /// Returns the current package, or null if the current process is not packaged
-            static Package Current { get; };
-            /// Returns the package from the system store with this full name or null if not found
-            static Package GetFromFullName(String fullName);
-            /// Returns packages in the given family, by name
-            static Package[] FindByFamilyName(String familyName);
-        }
-    }
-    ```
--->
+The syntactic interface of the Project Reunion SDK's clipboard API
+is an exact subset of Windows.ApplicationModel.DataTransfer, apart
+from a different name (Microsoft.ProjectReunion.ApplicationModel.DataTransfer).
+
+The set of types from Windows.ApplicationModel.DataTransfer that
+will be copied into the clipboard API is the following:
+
+* `Clipboard` - Top level for the clipboard API. Provides "static" methods
+  (methods implemented by the class's activation factory) to read and write
+  the current clipboard item and clipboard history, along with methods
+  to read settings for clipboard history and cloud clipboard sync.
+
+* `Clipboard`-related types:
+  * `ClipboardContentOptions`
+  * `ClipboardHistoryItem`
+  * `ClipboardHistoryItemsResult`
+  * `ClipboardHistoryItemsResultStatus`
+  * `ClipboardHistoryChangedEventArgs`
+  * `OperationCompletedEventArgs`
+  * `SetHistoryItemAsContentStatus`
+
+* `DataPackage` - Unit of data transfer for the clipboard API.
+
+* `DataPackage`-related types:
+  * `DataPackageView`
+  * `DataPackageOperation`
+  * `DataPackagePropertySet`
+  * `DataPackagePropertySetView`
+  * `DataProviderDeferral`
+  * `DataProviderHandler`
+  * `DataProviderRequest`
+  * `HtmlFormatHelper`
+  * `StandardDataFormats`
+
+\[To be expanded with IDL\]
 
 ## Appendix
 
-<!-- TEMPLATE
-    Anything else that you want to write down for posterity, but
-    that isn't necessary to understand the purpose and usage of the API.
-    For example, implementation details.
-    
--->
+Initially, the implementation of the Project Reunion SDK's clipboard APi
+will be a set of very thin wrappers around the same-named codes in
+Windows.ApplicationModel.DataTransfer.
+
+The only exception will be the change to make Clipboard.Flush()
+a completely optional operation.
+(TO CONSIDER: Should Clipboard.Flush() be removed entirely?)
+This will be implemented by Clipboard.SetContent(), which will register
+callbacks that call the underlying Clipboard.Flush() in
+Windows.ApplicationModel.DataTransfer when the application is about
+to exit or be suspended:
+
+* For apps that follow the [UWP app lifecycle](
+  https://docs.microsoft.com/windows/uwp/launch-resume/app-lifecycle),
+  a function that calls Clipboard.Flush() will be added as a handler for the
+  [`CoreApplication.EnteredBackground`](
+  https://docs.microsoft.com/uwp/api/windows.applicationmodel.core.coreapplication.enteredbackground)
+  event if that event is available, and
+  [`CoreApplication.Suspending`](
+  https://docs.microsoft.com/uwp/api/windows.applicationmodel.core.coreapplication.suspending)
+  otherwise.
+
+* For other apps, a worker thread will initialize COM in STA
+  and create a message-only user32.dll window, whose window procedure
+  handles WM_DESTROY by calling Clipboard.Flush(). When the application
+  exits normally, the window will receive WM_DESTROY.
+

--- a/specs/clipboard-api/clipboard.idl
+++ b/specs/clipboard-api/clipboard.idl
@@ -3,7 +3,6 @@
 import "inspectable.idl";
 import "AsyncInfo.idl";
 import "EventToken.idl";
-import "windowscontracts.idl";
 import "Windows.Foundation.idl";
 import "Windows.Foundation.Metadata.idl";
 import "Windows.Security.EnterpriseData.idl";
@@ -16,8 +15,6 @@ import "Windows.UI.idl";
 namespace Windows.Foundation
 {
 	typedef struct DateTime DateTime;
-	runtimeclass Deferral;
-	typedef struct Rect Rect;
 	runtimeclass Uri;
 }
 
@@ -38,8 +35,8 @@ namespace Windows.Security.EnterpriseData
 
 namespace Windows.Storage
 {
-	interface IStorageFile;
 	interface IStorageItem;
+	interface IStorageFile;
 	runtimeclass StorageFile;
 }
 
@@ -59,25 +56,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 	typedef enum ClipboardHistoryItemsResultStatus ClipboardHistoryItemsResultStatus;
 	typedef enum DataPackageOperation DataPackageOperation;
 	typedef enum SetHistoryItemAsContentStatus SetHistoryItemAsContentStatus;
-	typedef enum ShareUITheme ShareUITheme;
 	delegate DataProviderHandler;
-	delegate ShareProviderHandler;
-	interface IDataRequest;
-	interface IDataRequestDeferral;
-	interface IDataRequestedEventArgs;
-	interface IDataTransferManager;
-	interface IDataTransferManager2;
-	interface IDataTransferManagerStatics;
-	interface IDataTransferManagerStatics2;
-	interface IDataTransferManagerStatics3;
-	interface IShareCompletedEventArgs;
-	interface IShareProvider;
-	interface IShareProviderFactory;
-	interface IShareProviderOperation;
-	interface IShareProvidersRequestedEventArgs;
-	interface IShareTargetInfo;
-	interface IShareUIOptions;
-	interface ITargetApplicationChosenEventArgs;
 	runtimeclass Clipboard;
 	runtimeclass ClipboardContentOptions;
 	runtimeclass ClipboardHistoryChangedEventArgs;
@@ -89,21 +68,9 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 	runtimeclass DataPackageView;
 	runtimeclass DataProviderDeferral;
 	runtimeclass DataProviderRequest;
-	runtimeclass DataRequest;
-	runtimeclass DataRequestDeferral;
-	runtimeclass DataRequestedEventArgs;
-	runtimeclass DataTransferManager;
 	runtimeclass HtmlFormatHelper;
 	runtimeclass OperationCompletedEventArgs;
-	runtimeclass ShareCompletedEventArgs;
-	runtimeclass ShareProvider;
-	runtimeclass ShareProviderOperation;
-	runtimeclass ShareProvidersRequestedEventArgs;
-	runtimeclass ShareTargetInfo;
-	runtimeclass ShareUIOptions;
-	runtimeclass SharedStorageAccessManager;
 	runtimeclass StandardDataFormats;
-	runtimeclass TargetApplicationChosenEventArgs;
 }
 
 // Generic instantiations
@@ -111,23 +78,15 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 {
 	declare
 	{
-		interface Windows.Foundation.Collections.IIterable<Microsoft.ProjectReunion.ApplicationModel.ClipboardHistoryItem*>;
-		interface Windows.Foundation.Collections.IIterable<Microsoft.ProjectReunion.ApplicationModel.ShareProvider*>;
-		interface Windows.Foundation.Collections.IIterator<Microsoft.ProjectReunion.ApplicationModel.ClipboardHistoryItem*>;
-		interface Windows.Foundation.Collections.IIterator<Microsoft.ProjectReunion.ApplicationModel.ShareProvider*>;
-		interface Windows.Foundation.Collections.IVectorView<Microsoft.ProjectReunion.ApplicationModel.ClipboardHistoryItem*>;
-		interface Windows.Foundation.Collections.IVectorView<Microsoft.ProjectReunion.ApplicationModel.ShareProvider*>;
-		interface Windows.Foundation.Collections.IVector<Microsoft.ProjectReunion.ApplicationModel.ShareProvider*>;
-		interface Windows.Foundation.EventHandler<Microsoft.ProjectReunion.ApplicationModel.ClipboardHistoryChangedEventArgs*>;
-		interface Windows.Foundation.IAsyncOperation<Microsoft.ProjectReunion.ApplicationModel.ClipboardHistoryItemsResult*>;
-		interface Windows.Foundation.IAsyncOperation<Microsoft.ProjectReunion.ApplicationModel.DataPackage*>;
-		interface Windows.Foundation.IAsyncOperation<Microsoft.ProjectReunion.ApplicationModel.DataPackageOperation>;
-		interface Windows.Foundation.TypedEventHandler<Microsoft.ProjectReunion.ApplicationModel.DataPackage*, IInspectable*>;
-		interface Windows.Foundation.TypedEventHandler<Microsoft.ProjectReunion.ApplicationModel.DataPackage*, Microsoft.ProjectReunion.ApplicationModel.OperationCompletedEventArgs*>;
-		interface Windows.Foundation.TypedEventHandler<Microsoft.ProjectReunion.ApplicationModel.DataPackage*, Microsoft.ProjectReunion.ApplicationModel.ShareCompletedEventArgs*>;
-		interface Windows.Foundation.TypedEventHandler<Microsoft.ProjectReunion.ApplicationModel.DataTransferManager*, Microsoft.ProjectReunion.ApplicationModel.DataRequestedEventArgs*>;
-		interface Windows.Foundation.TypedEventHandler<Microsoft.ProjectReunion.ApplicationModel.DataTransferManager*, Microsoft.ProjectReunion.ApplicationModel.ShareProvidersRequestedEventArgs*>;
-		interface Windows.Foundation.TypedEventHandler<Microsoft.ProjectReunion.ApplicationModel.DataTransferManager*, Microsoft.ProjectReunion.ApplicationModel.TargetApplicationChosenEventArgs*>;
+		interface Windows.Foundation.Collections.IIterable<ClipboardHistoryItem*>;
+		interface Windows.Foundation.Collections.IIterator<ClipboardHistoryItem*>;
+		interface Windows.Foundation.Collections.IVectorView<ClipboardHistoryItem*>;
+		interface Windows.Foundation.EventHandler<ClipboardHistoryChangedEventArgs*>;
+		interface Windows.Foundation.IAsyncOperation<ClipboardHistoryItemsResult*>;
+		interface Windows.Foundation.IAsyncOperation<DataPackage*>;
+		interface Windows.Foundation.IAsyncOperation<DataPackageOperation>;
+		interface Windows.Foundation.TypedEventHandler<DataPackage*, IInspectable*>;
+		interface Windows.Foundation.TypedEventHandler<DataPackage*, OperationCompletedEventArgs*>;
 	}
 }
 
@@ -142,7 +101,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 	{
 		aaaSuccess                  = 0,
 		aaaAccessDenied             = 1,
-		aaaClipboardHistoryDisabled = 2
+		aaaClipboardHistoryDisabled = 2,
 	};
 
 	[contract(ClipboardContract, 1.0)]
@@ -152,7 +111,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 		aaaNone = 0x0,
 		aaaCopy = 0x1,
 		aaaMove = 0x2,
-		aaaLink = 0x4
+		aaaLink = 0x4,
 	};
 
 	[contract(ClipboardContract, 7.0)]
@@ -160,174 +119,12 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 	{
 		aaaSuccess      = 0,
 		aaaAccessDenied = 1,
-		aaaItemDeleted  = 2
-	};
-
-	[contract(ClipboardContract, 5.0)]
-	enum ShareUITheme
-	{
-		aaaDefault = 0,
-		aaaLight   = 1,
-		aaaDark    = 2
+		aaaItemDeleted  = 2,
 	};
 
 	[contract(ClipboardContract, 1.0)]
 	[uuid(6d9e7bfb-3280-4219-be29-08145f30f4e5)]
 	delegate void DataProviderHandler(DataProviderRequest request);
-
-	[contract(ClipboardContract, 4.0)]
-	[uuid(0d89ad1d-bb56-43e0-89d3-df5f85af2dd6)]
-	delegate
-		HRESULT ShareProviderHandler([in] Microsoft.ProjectReunion.ApplicationModel.ShareProviderOperation* operation);
-
-	[contract(ClipboardContract, 1.0)]
-	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataRequest)]
-	[uuid(6a17e08b-8a32-484c-a07a-d416c04277cb)]
-	interface IDataRequest : IInspectable
-	{
-		[propget] HRESULT Data([out] [retval] Microsoft.ProjectReunion.ApplicationModel.DataPackage** value);
-		[propput] HRESULT Data([in] Microsoft.ProjectReunion.ApplicationModel.DataPackage* value);
-		[propget] HRESULT Deadline([out] [retval] Windows.Foundation.DateTime* value);
-		HRESULT FailWithDisplayText([in] HSTRING value);
-		HRESULT GetDeferral([out] [retval] Microsoft.ProjectReunion.ApplicationModel.DataRequestDeferral** value);
-	}
-
-	[contract(ClipboardContract, 1.0)]
-	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataRequestDeferral)]
-	[uuid(dbb4bb17-24d4-45c7-b668-18b162942504)]
-	interface IDataRequestDeferral : IInspectable
-	{
-		HRESULT Complete();
-	}
-
-	[contract(ClipboardContract, 1.0)]
-	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataRequestedEventArgs)]
-	[uuid(e169b0d1-224d-42e1-84b7-1851d72da4e0)]
-	interface IDataRequestedEventArgs : IInspectable
-	{
-		[propget] HRESULT Request([out] [retval] Microsoft.ProjectReunion.ApplicationModel.DataRequest** value);
-	}
-
-	[contract(ClipboardContract, 1.0)]
-	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataTransferManager)]
-	[uuid(d55b10ac-e3c1-4b9d-ba05-e28056811f4b)]
-	interface IDataTransferManager : IInspectable
-	{
-		[eventadd] HRESULT DataRequested([in] Windows.Foundation.TypedEventHandler<Microsoft.ProjectReunion.ApplicationModel.DataTransferManager*, Microsoft.ProjectReunion.ApplicationModel.DataRequestedEventArgs*>* eventHandler, [out] [retval] EventRegistrationToken* eventCookie);
-		[eventremove] HRESULT DataRequested([in] EventRegistrationToken eventCookie);
-		[eventadd] HRESULT TargetApplicationChosen([in] Windows.Foundation.TypedEventHandler<Microsoft.ProjectReunion.ApplicationModel.DataTransferManager*, Microsoft.ProjectReunion.ApplicationModel.TargetApplicationChosenEventArgs*>* eventHandler, [out] [retval] EventRegistrationToken* eventCookie);
-		[eventremove] HRESULT TargetApplicationChosen([in] EventRegistrationToken eventCookie);
-	}
-
-	[contract(ClipboardContract, 4.0)]
-	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataTransferManager)]
-	[uuid(11c45fc0-76d6-4ff2-86f5-91481511b26c)]
-	interface IDataTransferManager2 : IInspectable
-	{
-		[eventadd] HRESULT ShareProvidersRequested([in] Windows.Foundation.TypedEventHandler<Microsoft.ProjectReunion.ApplicationModel.DataTransferManager*, Microsoft.ProjectReunion.ApplicationModel.ShareProvidersRequestedEventArgs*>* handler, [out] [retval] EventRegistrationToken* token);
-		[eventremove] HRESULT ShareProvidersRequested([in] EventRegistrationToken token);
-	}
-
-	[contract(ClipboardContract, 1.0)]
-	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataTransferManager)]
-	[uuid(0dc0af01-b3ae-484c-9752-910ce975392f)]
-	interface IDataTransferManagerStatics : IInspectable
-	{
-		HRESULT ShowShareUI();
-		HRESULT GetForCurrentView([out] [retval] Microsoft.ProjectReunion.ApplicationModel.DataTransferManager** value);
-	}
-
-	[contract(ClipboardContract, 3.0)]
-	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataTransferManager)]
-	[uuid(0e9a748d-3b26-4b7b-9399-ee372d58bf32)]
-	interface IDataTransferManagerStatics2 : IInspectable
-	{
-		HRESULT IsSupported([out] [retval] boolean* value);
-	}
-
-	[contract(ClipboardContract, 5.0)]
-	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataTransferManager)]
-	[uuid(dfd9220a-e51c-4dad-8b41-86d15192faab)]
-	interface IDataTransferManagerStatics3 : IInspectable
-	{
-		[overload("ShowShareUI")] HRESULT ShowShareUIWithOptions([in] Microsoft.ProjectReunion.ApplicationModel.ShareUIOptions* options);
-	}
-
-	[contract(ClipboardContract, 4.0)]
-	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.ShareCompletedEventArgs)]
-	[uuid(5107a2a6-6dd3-491a-8f1a-93a1867afa56)]
-	interface IShareCompletedEventArgs : IInspectable
-	{
-		[propget] HRESULT ShareTarget([out] [retval] Microsoft.ProjectReunion.ApplicationModel.ShareTargetInfo** value);
-	}
-
-	[contract(ClipboardContract, 4.0)]
-	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.ShareProvider)]
-	[uuid(6dcdc9a9-7118-43c5-ab39-c5b81ae919b3)]
-	interface IShareProvider : IInspectable
-	{
-		[propget] HRESULT Title([out] [retval] HSTRING* value);
-		[propget] HRESULT DisplayIcon([out] [retval] Windows.Storage.Streams.RandomAccessStreamReference** value);
-		[propget] HRESULT BackgroundColor([out] [retval] Windows.UI.Color* value);
-		[propget] HRESULT Tag([out] [retval] IInspectable** value);
-		[propput] HRESULT Tag([in] IInspectable* value);
-	}
-
-	[contract(ClipboardContract, 4.0)]
-	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.ShareProvider)]
-	[uuid(05994b01-3050-46ea-a2f1-db35deb79ab5)]
-	interface IShareProviderFactory : IInspectable
-	{
-		HRESULT Create([in] HSTRING title, [in] Windows.Storage.Streams.RandomAccessStreamReference* displayIcon, [in] Windows.UI.Color backgroundColor, [in] Microsoft.ProjectReunion.ApplicationModel.ShareProviderHandler* handler, [out] [retval] Microsoft.ProjectReunion.ApplicationModel.ShareProvider** result);
-	}
-
-	[contract(ClipboardContract, 4.0)]
-	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.ShareProviderOperation)]
-	[uuid(6956d6f1-ab46-4bcf-a1d3-be8e9a7d31e7)]
-	interface IShareProviderOperation : IInspectable
-	{
-		[propget] HRESULT Data([out] [retval] Microsoft.ProjectReunion.ApplicationModel.DataPackageView** value);
-		[propget] HRESULT Provider([out] [retval] Microsoft.ProjectReunion.ApplicationModel.ShareProvider** value);
-		HRESULT ReportCompleted();
-	}
-
-	[contract(ClipboardContract, 4.0)]
-	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.ShareProvidersRequestedEventArgs)]
-	[uuid(7314a2ef-4a97-4e53-b347-2316b67e9121)]
-	interface IShareProvidersRequestedEventArgs : IInspectable
-	{
-		[propget] HRESULT Providers([out] [retval] Windows.Foundation.Collections.IVector<Microsoft.ProjectReunion.ApplicationModel.ShareProvider*>** value);
-		[propget] HRESULT Data([out] [retval] Microsoft.ProjectReunion.ApplicationModel.DataPackageView** value);
-		HRESULT GetDeferral([out] [retval] Windows.Foundation.Deferral** value);
-	}
-
-	[contract(ClipboardContract, 4.0)]
-	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.ShareTargetInfo)]
-	[uuid(9b7ceae7-5d6f-4d29-9a17-427208267b9d)]
-	interface IShareTargetInfo : IInspectable
-	{
-		[propget] HRESULT AppUserModelId([out] [retval] HSTRING* value);
-		[propget] HRESULT ShareProvider([out] [retval] Microsoft.ProjectReunion.ApplicationModel.ShareProvider** value);
-	}
-
-	[contract(ClipboardContract, 5.0)]
-	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.ShareUIOptions)]
-	[uuid(443a3262-9729-40e4-819c-015f62b4d1c5)]
-	interface IShareUIOptions : IInspectable
-	{
-		[propget] HRESULT Theme([out] [retval] Microsoft.ProjectReunion.ApplicationModel.ShareUITheme* value);
-		[propput] HRESULT Theme([in] Microsoft.ProjectReunion.ApplicationModel.ShareUITheme value);
-		[propget] HRESULT SelectionRect([out] [retval] Windows.Foundation.IReference<Windows.Foundation.Rect>** value);
-		[propput] HRESULT SelectionRect([in] Windows.Foundation.IReference<Windows.Foundation.Rect>* value);
-	}
-
-	[contract(ClipboardContract, 1.0)]
-	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.TargetApplicationChosenEventArgs)]
-	[uuid(cdaa58b4-c944-4c6b-a8f4-f429131cc2ee)]
-	interface ITargetApplicationChosenEventArgs : IInspectable
-	{
-		[propget] HRESULT ApplicationName([out] [retval] HSTRING* value);
-	}
 
 	[contract(ClipboardContract, 7.0)]
 	[static_name("Microsoft.ProjectReunion.ApplicationModel.IClipboardStatics", 6cb53030-4da0-43a1-95ab-52f87cf59c3a)]
@@ -421,10 +218,6 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 
 		void SetApplicationLink(Windows.Foundation.Uri value);
 		void SetWebLink(Windows.Foundation.Uri value);
-
-		event Windows.Foundation.TypedEventHandler<DataPackage, ShareCompletedEventArgs> ShareCompleted;
-
-		event Windows.Foundation.TypedEventHandler<DataPackage, Object> ShareCanceled;
 	}
 
 	[contract(ClipboardContract, 6.0)]
@@ -551,39 +344,6 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 		void SetData(Object value);
 	}
 
-	[contract(ClipboardContract, 1.0)]
-	[marshaling_behavior(agile)]
-	runtimeclass DataRequest
-	{
-		[default] interface Microsoft.ProjectReunion.ApplicationModel.IDataRequest;
-	}
-
-	[contract(ClipboardContract, 1.0)]
-	[marshaling_behavior(agile)]
-	runtimeclass DataRequestDeferral
-	{
-		[default] interface Microsoft.ProjectReunion.ApplicationModel.IDataRequestDeferral;
-	}
-
-	[contract(ClipboardContract, 1.0)]
-	[marshaling_behavior(agile)]
-	runtimeclass DataRequestedEventArgs
-	{
-		[default] interface Microsoft.ProjectReunion.ApplicationModel.IDataRequestedEventArgs;
-	}
-
-	[contract(ClipboardContract, 1.0)]
-	[marshaling_behavior(standard)]
-	[static(Microsoft.ProjectReunion.ApplicationModel.IDataTransferManagerStatics, ClipboardContract, 1.0)]
-	[static(Microsoft.ProjectReunion.ApplicationModel.IDataTransferManagerStatics2, ClipboardContract, 3.0)]
-	[static(Microsoft.ProjectReunion.ApplicationModel.IDataTransferManagerStatics3, ClipboardContract, 5.0)]
-	runtimeclass DataTransferManager
-	{
-		[default] interface Microsoft.ProjectReunion.ApplicationModel.IDataTransferManager;
-		[contract(ClipboardContract, 4.0)] interface Microsoft.ProjectReunion.ApplicationModel.IDataTransferManager2;
-	}
-
-	[contract(ClipboardContract, 1.0)]
 	[static_name("Microsoft.ProjectReunion.ApplicationModel.IHtmlFormatHelperStatics", cce26a46-4048-4fb4-99c8-b822d03cd526)]
 	static runtimeclass HtmlFormatHelper
 	{
@@ -598,60 +358,6 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 		DataPackageOperation Operation { get; };
 
 		String AcceptedFormatId { get; };
-	}
-
-	[contract(ClipboardContract, 4.0)]
-	[marshaling_behavior(agile)]
-	runtimeclass ShareCompletedEventArgs
-	{
-		[default] interface Microsoft.ProjectReunion.ApplicationModel.IShareCompletedEventArgs;
-	}
-
-	[activatable(Microsoft.ProjectReunion.ApplicationModel.IShareProviderFactory, ClipboardContract, 4.0)]
-	[contract(ClipboardContract, 4.0)]
-	[marshaling_behavior(agile)]
-	runtimeclass ShareProvider
-	{
-		[default] interface Microsoft.ProjectReunion.ApplicationModel.IShareProvider;
-	}
-
-	[contract(ClipboardContract, 4.0)]
-	[marshaling_behavior(agile)]
-	runtimeclass ShareProviderOperation
-	{
-		[default] interface Microsoft.ProjectReunion.ApplicationModel.IShareProviderOperation;
-	}
-
-	[contract(ClipboardContract, 4.0)]
-	[marshaling_behavior(agile)]
-	runtimeclass ShareProvidersRequestedEventArgs
-	{
-		[default] interface Microsoft.ProjectReunion.ApplicationModel.IShareProvidersRequestedEventArgs;
-	}
-
-	[contract(ClipboardContract, 4.0)]
-	[marshaling_behavior(agile)]
-	runtimeclass ShareTargetInfo
-	{
-		[default] interface Microsoft.ProjectReunion.ApplicationModel.IShareTargetInfo;
-	}
-
-	[activatable(ClipboardContract, 5.0)]
-	[contract(ClipboardContract, 5.0)]
-	[marshaling_behavior(agile)]
-	[threading(both)]
-	runtimeclass ShareUIOptions
-	{
-		[default] interface Microsoft.ProjectReunion.ApplicationModel.IShareUIOptions;
-	}
-
-	[contract(ClipboardContract, 1.0)]
-	[static_name("Microsoft.ProjectReunion.ApplicationModel.ISharedStorageAccessManagerStatics", 9b5b520e-1b1a-487a-be92-f214f21c255f)]
-	static runtimeclass SharedStorageAccessManager
-	{
-		static String AddFile(Windows.Storage.IStorageFile file);
-		static Windows.Foundation.IAsyncOperation<Windows.Storage.StorageFile> RedeemTokenForFileAsync(String token);
-		static void RemoveFile(String token);
 	}
 
 	[contract(ClipboardContract, 6.0)]
@@ -672,10 +378,4 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 		static String UserActivityJsonArray { get; };
 	}
 
-	[contract(ClipboardContract, 1.0)]
-	[marshaling_behavior(agile)]
-	runtimeclass TargetApplicationChosenEventArgs
-	{
-		[default] interface Microsoft.ProjectReunion.ApplicationModel.ITargetApplicationChosenEventArgs;
-	}
 }

--- a/specs/clipboard-api/clipboard.idl
+++ b/specs/clipboard-api/clipboard.idl
@@ -62,8 +62,6 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 	typedef enum ShareUITheme ShareUITheme;
 	delegate DataProviderHandler;
 	delegate ShareProviderHandler;
-	interface IDataProviderDeferral;
-	interface IDataProviderRequest;
 	interface IDataRequest;
 	interface IDataRequestDeferral;
 	interface IDataRequestedEventArgs;
@@ -175,32 +173,12 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 
 	[contract(ClipboardContract, 1.0)]
 	[uuid(6d9e7bfb-3280-4219-be29-08145f30f4e5)]
-	delegate
-		HRESULT DataProviderHandler([in] Microsoft.ProjectReunion.ApplicationModel.DataProviderRequest* request);
+	delegate void DataProviderHandler(DataProviderRequest request);
 
 	[contract(ClipboardContract, 4.0)]
 	[uuid(0d89ad1d-bb56-43e0-89d3-df5f85af2dd6)]
 	delegate
 		HRESULT ShareProviderHandler([in] Microsoft.ProjectReunion.ApplicationModel.ShareProviderOperation* operation);
-
-	[contract(ClipboardContract, 1.0)]
-	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataProviderDeferral)]
-	[uuid(4f9a822c-1bb1-4c3e-b908-e202c8b87f4c)]
-	interface IDataProviderDeferral : IInspectable
-	{
-		HRESULT Complete();
-	}
-
-	[contract(ClipboardContract, 1.0)]
-	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataProviderRequest)]
-	[uuid(25f2c71c-832b-4b8e-b9e9-672f098d2770)]
-	interface IDataProviderRequest : IInspectable
-	{
-		[propget] HRESULT FormatId([out] [retval] HSTRING* value);
-		[propget] HRESULT Deadline([out] [retval] Windows.Foundation.DateTime* value);
-		HRESULT GetDeferral([out] [retval] Microsoft.ProjectReunion.ApplicationModel.DataProviderDeferral** value);
-		HRESULT SetData([in] IInspectable* value);
-	}
 
 	[contract(ClipboardContract, 1.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataRequest)]
@@ -557,17 +535,20 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 	}
 
 	[contract(ClipboardContract, 1.0)]
-	[marshaling_behavior(agile)]
+	[interface_name("Microsoft.ProjectReunion.ApplicationModel.IDataProviderDeferral", 4f9a822c-1bb1-4c3e-b908-e202c8b87f4c)]
 	runtimeclass DataProviderDeferral
 	{
-		[default] interface Microsoft.ProjectReunion.ApplicationModel.IDataProviderDeferral;
+		void Complete();
 	}
 
 	[contract(ClipboardContract, 1.0)]
-	[marshaling_behavior(agile)]
+	[interface_name("Microsoft.ProjectReunion.ApplicationModel.IDataProviderRequest", 25f2c71c-832b-4b8e-b9e9-672f098d2770)]
 	runtimeclass DataProviderRequest
 	{
-		[default] interface Microsoft.ProjectReunion.ApplicationModel.IDataProviderRequest;
+		String FormatId { get; };
+		Windows.Foundation.DateTime Deadline { get; };
+		DataProviderDeferral GetDeferral();
+		void SetData(Object value);
 	}
 
 	[contract(ClipboardContract, 1.0)]

--- a/specs/clipboard-api/clipboard.idl
+++ b/specs/clipboard-api/clipboard.idl
@@ -20,6 +20,10 @@ namespace Windows.Foundation
 
 namespace Windows.Foundation.Metadata
 {
+
+	// FIXME: Figure out how to actually forward declare/prototype this WinRT Foundation attribute
+	// without defining it
+
 	[attributeusage(target_all)]
 	[attributename("hasvariant")]
 	[version(NTDDI_WIN8)]
@@ -53,6 +57,9 @@ namespace Windows.UI
 
 namespace Microsoft.ProjectReunion.ApplicationModel
 {
+	[contractversion(1.0)]
+	apicontract ClipboardContract { };
+
 	typedef enum ClipboardHistoryItemsResultStatus ClipboardHistoryItemsResultStatus;
 	typedef enum DataPackageOperation DataPackageOperation;
 	typedef enum SetHistoryItemAsContentStatus SetHistoryItemAsContentStatus;
@@ -90,13 +97,14 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 	}
 }
 
-// Type definition
+// Type definitions
 namespace Microsoft.ProjectReunion.ApplicationModel
 {
-	[contractversion(12.0)]
-	apicontract ClipboardContract { };
+	// FIXME: Figure out how to declare these enums without causing definition conflicts
+	// between the enum constants and the same-named ones in
+	// Windows.ApplicationModel.DataTransfer
 
-	[contract(ClipboardContract, 7.0)]
+	[contract(ClipboardContract, 1.0)]
 	enum ClipboardHistoryItemsResultStatus
 	{
 		aaaSuccess                  = 0,
@@ -114,7 +122,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 		aaaLink = 0x4,
 	};
 
-	[contract(ClipboardContract, 7.0)]
+	[contract(ClipboardContract, 1.0)]
 	enum SetHistoryItemAsContentStatus
 	{
 		aaaSuccess      = 0,
@@ -126,7 +134,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 	[uuid(6d9e7bfb-3280-4219-be29-08145f30f4e5)]
 	delegate void DataProviderHandler(DataProviderRequest request);
 
-	[contract(ClipboardContract, 7.0)]
+	[contract(ClipboardContract, 1.0)]
 	[static_name("Microsoft.ProjectReunion.ApplicationModel.IClipboardStatics", 6cb53030-4da0-43a1-95ab-52f87cf59c3a)]
 	[marshaling_behavior(standard)]
 	static runtimeclass Clipboard
@@ -153,7 +161,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 		static event Windows.Foundation.EventHandler<Object> HistoryEnabledChanged;
 	}
 
-	[contract(ClipboardContract, 7.0)]
+	[contract(ClipboardContract, 1.0)]
 	[interface_name("Microsoft.ProjectReunion.ApplicationModel.IClipboardContentOptions", c31b927f-1008-4e98-b575-adf175ccdd0b)]
 	runtimeclass ClipboardContentOptions
 	{
@@ -165,13 +173,12 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 		Windows.Foundation.Collections.IVector<String> HistoryFormats { get; };
 	}
 
-	[contract(ClipboardContract, 7.0)]
+	[contract(ClipboardContract, 1.0)]
 	[interface_name("Microsoft.ProjectReunion.ApplicationModel.IClipboardHistoryChangedEventArgs", 9d1960c7-cf0a-4e51-943c-72373b7a2579)]
 	runtimeclass ClipboardHistoryChangedEventArgs
-	{
-	}
+	{ }
 
-	[contract(ClipboardContract, 7.0)]
+	[contract(ClipboardContract, 1.0)]
 	[interface_name("Microsoft.ProjectReunion.ApplicationModel.IClipboardHistoryItem", 1907eff8-7d2f-4a71-8a56-bd02effeb184)]
 	runtimeclass ClipboardHistoryItem
 	{
@@ -180,7 +187,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 		DataPackageView Content { get; };
 	}
 
-	[contract(ClipboardContract, 7.0)]
+	[contract(ClipboardContract, 1.0)]
 	[interface_name("Microsoft.ProjectReunion.ApplicationModel.IClipboardHistoryItemsResult", 2f6c9705-f56b-42f0-b1a1-fc2d46d572e7)]
 	runtimeclass ClipboardHistoryItemsResult
 	{
@@ -188,7 +195,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 		Windows.Foundation.Collections.IVectorView<ClipboardHistoryItem> Items { get; };
 	}
 
-	[contract(ClipboardContract, 10.0)]
+	[contract(ClipboardContract, 1.0)]
 	[interface_name("Microsoft.ProjectReunion.ApplicationModel.IDataPackage", 36861532-b01e-49c5-9a0b-2282d079c9ac)]
 	runtimeclass DataPackage
 	{
@@ -202,7 +209,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 		void SetData(String formatId, [hasvariant] Object value);
 		void SetDataProvider(String formatId, DataProviderHandler delayRenderer);
 		void SetText(String value);
-		[deprecated("SetUri may be altered or unavailable in future releases. Instead, use SetWebLink or SetApplicationLink.", deprecate, ClipboardContract, 10.0)]
+		[deprecated("SetUri may be altered or unavailable in future releases. Instead, use SetWebLink or SetApplicationLink.", deprecate, ClipboardContract, 1.0)]
 		void SetUri(Windows.Foundation.Uri value);
 		void SetHtmlFormat(String value);
 
@@ -220,14 +227,14 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 		void SetWebLink(Windows.Foundation.Uri value);
 	}
 
-	[contract(ClipboardContract, 6.0)]
+	[contract(ClipboardContract, 1.0)]
 	runtimeclass DataPackagePropertySet :
 		[default] IDataPackagePropertySet
 		, Windows.Foundation.Collections.IMap<String, Object>
 		, Windows.Foundation.Collections.IIterable<Windows.Foundation.Collections.IKeyValuePair<String, Object> >
 	{ }
 
-	[contract(ClipboardContract, 6.0)]
+	[contract(ClipboardContract, 1.0)]
 	[uuid(6c1bd5dd-d89e-4f79-ae3b-4ad565586202)]
 	[exclusiveto(DataPackagePropertySet)]
 	[hasvariant]
@@ -253,14 +260,14 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 		String ContentSourceUserActivityJson;
 	}
 
-	[contract(ClipboardContract, 7.0)]
+	[contract(ClipboardContract, 1.0)]
 	runtimeclass DataPackagePropertySetView :
 		[default] IDataPackagePropertySetView
 		, Windows.Foundation.Collections.IMapView<String, Object>
 		, Windows.Foundation.Collections.IIterable<Windows.Foundation.Collections.IKeyValuePair<String, Object> >
 	{ }
 
-	[contract(ClipboardContract, 7.0)]
+	[contract(ClipboardContract, 1.0)]
 	[uuid(054c0bc4-ca76-4e7d-9511-4322a5a0b58b)]
 	[exclusiveto(DataPackagePropertySetView)]
 	[hasvariant]
@@ -288,7 +295,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 		Boolean IsFromRoamingClipboard { get; };
 	}
 
-	[contract(ClipboardContract, 2.0)]
+	[contract(ClipboardContract, 1.0)]
 	[interface_name("Microsoft.ProjectReunion.ApplicationModel.IDataPackageView", 659f7a31-3335-4e57-b373-8898ffae5ab1)]
 	runtimeclass DataPackageView
 	{
@@ -307,7 +314,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 		[method_name("GetCustomTextAsync")]
 		Windows.Foundation.IAsyncOperation<String> GetTextAsync(String formatId);
 
-		[deprecated("GetUriAsync may be altered or unavailable in future releases. Instead, use GetWebLinkAsync or GetApplicationLinkAsync.", deprecate, ClipboardContract, 2.0)]
+		[deprecated("GetUriAsync may be altered or unavailable in future releases. Instead, use GetWebLinkAsync or GetApplicationLinkAsync.", deprecate, ClipboardContract, 1.0)]
 		Windows.Foundation.IAsyncOperation<Windows.Foundation.Uri> GetUriAsync();
 		Windows.Foundation.IAsyncOperation<String> GetHtmlFormatAsync();
 		Windows.Foundation.IAsyncOperation<Windows.Foundation.Collections.IMapView<String, Windows.Storage.Streams.RandomAccessStreamReference> > GetResourceMapAsync();
@@ -351,7 +358,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 		static String CreateHtmlFormat(String htmlFragment);
 	}
 
-	[contract(ClipboardContract, 2.0)]
+	[contract(ClipboardContract, 1.0)]
 	[interface_name("Microsoft.ProjectReunion.ApplicationModel.IOperationCompletedEventArgs", a180ab74-fcc7-42f3-a6bd-5d373a28fc8d)]
 	runtimeclass OperationCompletedEventArgs
 	{
@@ -360,12 +367,12 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 		String AcceptedFormatId { get; };
 	}
 
-	[contract(ClipboardContract, 6.0)]
+	[contract(ClipboardContract, 1.0)]
 	[static_name("Microsoft.ProjectReunion.ApplicationModel.IStandardDataFormatsStatics", 18f4cbf8-64f1-4ba1-9e64-53648a0443a8)]
 	static runtimeclass StandardDataFormats
 	{
 		static String Text { get; };
-		[deprecated("Uri may be altered or unavailable in future releases. Instead, use WebLink or ApplicationLink.", deprecate, ClipboardContract, 6.0)]
+		[deprecated("Uri may be altered or unavailable in future releases. Instead, use WebLink or ApplicationLink.", deprecate, ClipboardContract, 1.0)]
 		static String Uri { get; };
 		static String Html { get; };
 		static String Rtf { get; };

--- a/specs/clipboard-api/clipboard.idl
+++ b/specs/clipboard-api/clipboard.idl
@@ -450,8 +450,17 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 	}
 
 	[contract(ClipboardContract, 6.0)]
-	[interface_name("Microsoft.ProjectReunion.ApplicationModel.IDataPackagePropertySet", 6c1bd5dd-d89e-4f79-ae3b-4ad565586202)]
 	runtimeclass DataPackagePropertySet :
+		[default] IDataPackagePropertySet
+		, Windows.Foundation.Collections.IMap<String, Object>
+		, Windows.Foundation.Collections.IIterable<Windows.Foundation.Collections.IKeyValuePair<String, Object> >
+	{ }
+
+	[contract(ClipboardContract, 6.0)]
+	[uuid(6c1bd5dd-d89e-4f79-ae3b-4ad565586202)]
+	[exclusiveto(DataPackagePropertySet)]
+	[hasvariant]
+	interface IDataPackagePropertySet requires
 		Windows.Foundation.Collections.IMap<String, Object>
 		, Windows.Foundation.Collections.IIterable<Windows.Foundation.Collections.IKeyValuePair<String, Object> >
 	{
@@ -474,9 +483,17 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 	}
 
 	[contract(ClipboardContract, 7.0)]
-	[interface_name("Microsoft.ProjectReunion.ApplicationModel.IDataPackagePropertySetView", 054c0bc4-ca76-4e7d-9511-4322a5a0b58b)]
-	[hasvariant]
 	runtimeclass DataPackagePropertySetView :
+		[default] IDataPackagePropertySetView
+		, Windows.Foundation.Collections.IMapView<String, Object>
+		, Windows.Foundation.Collections.IIterable<Windows.Foundation.Collections.IKeyValuePair<String, Object> >
+	{ }
+
+	[contract(ClipboardContract, 7.0)]
+	[uuid(054c0bc4-ca76-4e7d-9511-4322a5a0b58b)]
+	[exclusiveto(DataPackagePropertySetView)]
+	[hasvariant]
+	interface IDataPackagePropertySetView requires
 		Windows.Foundation.Collections.IMapView<String, Object>
 		, Windows.Foundation.Collections.IIterable<Windows.Foundation.Collections.IKeyValuePair<String, Object> >
 	{

--- a/specs/clipboard-api/clipboard.idl
+++ b/specs/clipboard-api/clipboard.idl
@@ -16,7 +16,6 @@ namespace Windows.Foundation
 	typedef struct DateTime DateTime;
 	runtimeclass Deferral;
 	typedef struct Rect Rect;
-	apicontract UniversalApiContract;
 	runtimeclass Uri;
 }
 
@@ -155,15 +154,18 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 // Type definition
 namespace Microsoft.ProjectReunion.ApplicationModel
 {
-	[contract(Windows.Foundation.UniversalApiContract, 7.0)]
+	[contractversion(12.0)]
+	apicontract ClipboardContract { };
+
+	[contract(ClipboardContract, 7.0)]
 	enum ClipboardHistoryItemsResultStatus
 	{
-		Success					 = 0,
-		AccessDenied			 = 1,
+		Success                  = 0,
+		AccessDenied             = 1,
 		ClipboardHistoryDisabled = 2
 	};
 
-	[contract(Windows.Foundation.UniversalApiContract, 1.0)]
+	[contract(ClipboardContract, 1.0)]
 	[flags]
 	enum DataPackageOperation
 	{
@@ -173,33 +175,33 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 		Link = 0x4
 	};
 
-	[contract(Windows.Foundation.UniversalApiContract, 7.0)]
+	[contract(ClipboardContract, 7.0)]
 	enum SetHistoryItemAsContentStatus
 	{
-		Success		 = 0,
+		Success      = 0,
 		AccessDenied = 1,
-		ItemDeleted	 = 2
+		ItemDeleted  = 2
 	};
 
-	[contract(Windows.Foundation.UniversalApiContract, 5.0)]
+	[contract(ClipboardContract, 5.0)]
 	enum ShareUITheme
 	{
 		Default = 0,
-		Light	= 1,
-		Dark	= 2
+		Light   = 1,
+		Dark    = 2
 	};
 
-	[contract(Windows.Foundation.UniversalApiContract, 1.0)]
+	[contract(ClipboardContract, 1.0)]
 	[uuid(E7ECD720-F2F4-4A2D-920E-170A2F482A27)]
 	delegate
 		HRESULT DataProviderHandler([in] Microsoft.ProjectReunion.ApplicationModel.DataProviderRequest* request);
 
-	[contract(Windows.Foundation.UniversalApiContract, 4.0)]
+	[contract(ClipboardContract, 4.0)]
 	[uuid(E7F9D9BA-E1BA-4E4D-BD65-D43845D3212F)]
 	delegate
 		HRESULT ShareProviderHandler([in] Microsoft.ProjectReunion.ApplicationModel.ShareProviderOperation* operation);
 
-	[contract(Windows.Foundation.UniversalApiContract, 7.0)]
+	[contract(ClipboardContract, 7.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.ClipboardContentOptions)]
 	[uuid(E888A98C-AD4B-5447-A056-AB3556276D2B)]
 	interface IClipboardContentOptions : IInspectable
@@ -212,14 +214,14 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 		[propget] HRESULT HistoryFormats([out] [retval] Windows.Foundation.Collections.IVector<HSTRING>** value);
 	}
 
-	[contract(Windows.Foundation.UniversalApiContract, 7.0)]
+	[contract(ClipboardContract, 7.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.ClipboardHistoryChangedEventArgs)]
 	[uuid(C0BE453F-8EA2-53CE-9ABA-8D2212573452)]
 	interface IClipboardHistoryChangedEventArgs : IInspectable
 	{
 	}
 
-	[contract(Windows.Foundation.UniversalApiContract, 7.0)]
+	[contract(ClipboardContract, 7.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.ClipboardHistoryItem)]
 	[uuid(0173BD8A-AFFF-5C50-AB92-3D19F481EC58)]
 	interface IClipboardHistoryItem : IInspectable
@@ -229,7 +231,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 		[propget] HRESULT Content([out] [retval] Microsoft.ProjectReunion.ApplicationModel.DataPackageView** value);
 	}
 
-	[contract(Windows.Foundation.UniversalApiContract, 7.0)]
+	[contract(ClipboardContract, 7.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.ClipboardHistoryItemsResult)]
 	[uuid(E6DFDEE6-0EE2-52E3-852B-F295DB65939A)]
 	interface IClipboardHistoryItemsResult : IInspectable
@@ -238,7 +240,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 		[propget] HRESULT Items([out] [retval] Windows.Foundation.Collections.IVectorView<Microsoft.ProjectReunion.ApplicationModel.ClipboardHistoryItem*>** value);
 	}
 
-	[contract(Windows.Foundation.UniversalApiContract, 1.0)]
+	[contract(ClipboardContract, 1.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.Clipboard)]
 	[uuid(C627E291-34E2-4963-8EED-93CBB0EA3D70)]
 	interface IClipboardStatics : IInspectable
@@ -251,7 +253,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 		[eventremove] HRESULT ContentChanged([in] EventRegistrationToken token);
 	}
 
-	[contract(Windows.Foundation.UniversalApiContract, 7.0)]
+	[contract(ClipboardContract, 7.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.Clipboard)]
 	[uuid(D2AC1B6A-D29F-554B-B303-F0452345FE02)]
 	interface IClipboardStatics2 : IInspectable
@@ -271,7 +273,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 		[eventremove] HRESULT HistoryEnabledChanged([in] EventRegistrationToken token);
 	}
 
-	[contract(Windows.Foundation.UniversalApiContract, 1.0)]
+	[contract(ClipboardContract, 1.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataPackage)]
 	[uuid(61EBF5C7-EFEA-4346-9554-981D7E198FFE)]
 	interface IDataPackage : IInspectable
@@ -287,7 +289,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 		HRESULT SetData([in] HSTRING formatId, [in] IInspectable* value);
 		HRESULT SetDataProvider([in] HSTRING formatId, [in] Microsoft.ProjectReunion.ApplicationModel.DataProviderHandler* delayRenderer);
 		HRESULT SetText([in] HSTRING value);
-		[deprecated("SetUri may be altered or unavailable for releases after Windows Phone 'OSVersion' (TBD).Instead, use SetWebLink or SetApplicationLink.", deprecate, Windows.Foundation.UniversalApiContract, 1.0)] HRESULT SetUri([in] Windows.Foundation.Uri* value);
+		[deprecated("SetUri may be altered or unavailable for releases after Windows Phone 'OSVersion' (TBD).Instead, use SetWebLink or SetApplicationLink.", deprecate, ClipboardContract, 1.0)] HRESULT SetUri([in] Windows.Foundation.Uri* value);
 		HRESULT SetHtmlFormat([in] HSTRING value);
 		[propget] HRESULT ResourceMap([out] [retval] Windows.Foundation.Collections.IMap<HSTRING, Windows.Storage.Streams.RandomAccessStreamReference*>** value);
 		HRESULT SetRtf([in] HSTRING value);
@@ -296,7 +298,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 		[overload("SetStorageItems")] HRESULT SetStorageItems([in] Windows.Foundation.Collections.IIterable<Windows.Storage.IStorageItem*>* value, [in] boolean readOnly);
 	}
 
-	[contract(Windows.Foundation.UniversalApiContract, 1.0)]
+	[contract(ClipboardContract, 1.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataPackage)]
 	[uuid(041C1FE9-2409-45E1-A538-4C53EEEE04A7)]
 	interface IDataPackage2 : IInspectable
@@ -305,7 +307,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 		HRESULT SetWebLink([in] Windows.Foundation.Uri* value);
 	}
 
-	[contract(Windows.Foundation.UniversalApiContract, 4.0)]
+	[contract(ClipboardContract, 4.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataPackage)]
 	[uuid(88F31F5D-787B-4D32-965A-A9838105A056)]
 	interface IDataPackage3 : IInspectable
@@ -314,7 +316,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 		[eventremove] HRESULT ShareCompleted([in] EventRegistrationToken token);
 	}
 
-	[contract(Windows.Foundation.UniversalApiContract, 10.0)]
+	[contract(ClipboardContract, 10.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataPackage)]
 	[uuid(13A24EC8-9382-536F-852A-3045E1B29A3B)]
 	interface IDataPackage4 : IInspectable
@@ -323,7 +325,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 		[eventremove] HRESULT ShareCanceled([in] EventRegistrationToken token);
 	}
 
-	[contract(Windows.Foundation.UniversalApiContract, 1.0)]
+	[contract(ClipboardContract, 1.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataPackagePropertySet)]
 	[uuid(CD1C93EB-4C4C-443A-A8D3-F5C241E91689)]
 	interface IDataPackagePropertySet : IInspectable
@@ -344,7 +346,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 		[propput] HRESULT ApplicationListingUri([in] Windows.Foundation.Uri* value);
 	}
 
-	[contract(Windows.Foundation.UniversalApiContract, 1.0)]
+	[contract(ClipboardContract, 1.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataPackagePropertySet)]
 	[uuid(EB505D4A-9800-46AA-B181-7B6F0F2B919A)]
 	interface IDataPackagePropertySet2 : IInspectable
@@ -361,7 +363,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 		[propput] HRESULT LogoBackgroundColor([in] Windows.UI.Color value);
 	}
 
-	[contract(Windows.Foundation.UniversalApiContract, 1.0)]
+	[contract(ClipboardContract, 1.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataPackagePropertySet)]
 	[uuid(9E87FD9B-5205-401B-874A-455653BD39E8)]
 	interface IDataPackagePropertySet3 : IInspectable
@@ -370,7 +372,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 		[propput] HRESULT EnterpriseId([in] HSTRING value);
 	}
 
-	[contract(Windows.Foundation.UniversalApiContract, 6.0)]
+	[contract(ClipboardContract, 6.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataPackagePropertySet)]
 	[uuid(6390EBF5-1739-4C74-B22F-865FAB5E8545)]
 	interface IDataPackagePropertySet4 : IInspectable
@@ -379,7 +381,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 		[propput] HRESULT ContentSourceUserActivityJson([in] HSTRING value);
 	}
 
-	[contract(Windows.Foundation.UniversalApiContract, 1.0)]
+	[contract(ClipboardContract, 1.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataPackagePropertySetView)]
 	[uuid(B94CEC01-0C1A-4C57-BE55-75D01289735D)]
 	interface IDataPackagePropertySetView : IInspectable
@@ -392,7 +394,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 		[propget] HRESULT ApplicationListingUri([out] [retval] Windows.Foundation.Uri** value);
 	}
 
-	[contract(Windows.Foundation.UniversalApiContract, 1.0)]
+	[contract(ClipboardContract, 1.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataPackagePropertySetView)]
 	[uuid(6054509B-8EBE-4FEB-9C1E-75E69DE54B84)]
 	interface IDataPackagePropertySetView2 : IInspectable
@@ -404,7 +406,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 		[propget] HRESULT LogoBackgroundColor([out] [retval] Windows.UI.Color* value);
 	}
 
-	[contract(Windows.Foundation.UniversalApiContract, 1.0)]
+	[contract(ClipboardContract, 1.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataPackagePropertySetView)]
 	[uuid(DB764CE5-D174-495C-84FC-1A51F6AB45D7)]
 	interface IDataPackagePropertySetView3 : IInspectable
@@ -412,7 +414,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 		[propget] HRESULT EnterpriseId([out] [retval] HSTRING* value);
 	}
 
-	[contract(Windows.Foundation.UniversalApiContract, 6.0)]
+	[contract(ClipboardContract, 6.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataPackagePropertySetView)]
 	[uuid(4474C80D-D16F-40AE-9580-6F8562B94235)]
 	interface IDataPackagePropertySetView4 : IInspectable
@@ -420,7 +422,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 		[propget] HRESULT ContentSourceUserActivityJson([out] [retval] HSTRING* value);
 	}
 
-	[contract(Windows.Foundation.UniversalApiContract, 7.0)]
+	[contract(ClipboardContract, 7.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataPackagePropertySetView)]
 	[uuid(6F0A9445-3760-50BB-8523-C4202DED7D78)]
 	interface IDataPackagePropertySetView5 : IInspectable
@@ -428,7 +430,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 		[propget] HRESULT IsFromRoamingClipboard([out] [retval] boolean* value);
 	}
 
-	[contract(Windows.Foundation.UniversalApiContract, 1.0)]
+	[contract(ClipboardContract, 1.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataPackageView)]
 	[uuid(7B840471-5900-4D85-A90B-10CB85FE3552)]
 	interface IDataPackageView : IInspectable
@@ -441,7 +443,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 		HRESULT GetDataAsync([in] HSTRING formatId, [out] [retval] Windows.Foundation.IAsyncOperation<IInspectable*>** operation);
 		[overload("GetTextAsync")] HRESULT GetTextAsync([out] [retval] Windows.Foundation.IAsyncOperation<HSTRING>** operation);
 		[overload("GetTextAsync")] HRESULT GetCustomTextAsync([in] HSTRING formatId, [out] [retval] Windows.Foundation.IAsyncOperation<HSTRING>** operation);
-		[deprecated("GetUriAsync may be altered or unavailable for releases after Windows 8.1. Instead, use GetWebLinkAsync or GetApplicationLinkAsync.", deprecate, Windows.Foundation.UniversalApiContract, 1.0)] HRESULT GetUriAsync([out] [retval] Windows.Foundation.IAsyncOperation<Windows.Foundation.Uri*>** operation);
+		[deprecated("GetUriAsync may be altered or unavailable for releases after Windows 8.1. Instead, use GetWebLinkAsync or GetApplicationLinkAsync.", deprecate, ClipboardContract, 1.0)] HRESULT GetUriAsync([out] [retval] Windows.Foundation.IAsyncOperation<Windows.Foundation.Uri*>** operation);
 		HRESULT GetHtmlFormatAsync([out] [retval] Windows.Foundation.IAsyncOperation<HSTRING>** operation);
 		HRESULT GetResourceMapAsync([out] [retval] Windows.Foundation.IAsyncOperation<Windows.Foundation.Collections.IMapView<HSTRING, Windows.Storage.Streams.RandomAccessStreamReference*>*>** operation);
 		HRESULT GetRtfAsync([out] [retval] Windows.Foundation.IAsyncOperation<HSTRING>** operation);
@@ -449,7 +451,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 		HRESULT GetStorageItemsAsync([out] [retval] Windows.Foundation.IAsyncOperation<Windows.Foundation.Collections.IVectorView<Windows.Storage.IStorageItem*>*>** operation);
 	}
 
-	[contract(Windows.Foundation.UniversalApiContract, 1.0)]
+	[contract(ClipboardContract, 1.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataPackageView)]
 	[uuid(40ECBA95-2450-4C1D-B6B4-ED45463DEE9C)]
 	interface IDataPackageView2 : IInspectable
@@ -458,7 +460,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 		HRESULT GetWebLinkAsync([out] [retval] Windows.Foundation.IAsyncOperation<Windows.Foundation.Uri*>** operation);
 	}
 
-	[contract(Windows.Foundation.UniversalApiContract, 1.0)]
+	[contract(ClipboardContract, 1.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataPackageView)]
 	[uuid(D37771A8-DDAD-4288-8428-D1CAE394128B)]
 	interface IDataPackageView3 : IInspectable
@@ -468,7 +470,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 		HRESULT UnlockAndAssumeEnterpriseIdentity([out] [retval] Windows.Security.EnterpriseData.ProtectionPolicyEvaluationResult* result);
 	}
 
-	[contract(Windows.Foundation.UniversalApiContract, 2.0)]
+	[contract(ClipboardContract, 2.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataPackageView)]
 	[uuid(DFE96F1F-E042-4433-A09F-26D6FFDA8B85)]
 	interface IDataPackageView4 : IInspectable
@@ -476,7 +478,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 		HRESULT SetAcceptedFormatId([in] HSTRING formatId);
 	}
 
-	[contract(Windows.Foundation.UniversalApiContract, 1.0)]
+	[contract(ClipboardContract, 1.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataProviderDeferral)]
 	[uuid(C2CF2373-2D26-43D9-B69D-DCB86D03F6DA)]
 	interface IDataProviderDeferral : IInspectable
@@ -484,7 +486,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 		HRESULT Complete();
 	}
 
-	[contract(Windows.Foundation.UniversalApiContract, 1.0)]
+	[contract(ClipboardContract, 1.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataProviderRequest)]
 	[uuid(EBBC7157-D3C8-47DA-ACDE-F82388D5F716)]
 	interface IDataProviderRequest : IInspectable
@@ -495,7 +497,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 		HRESULT SetData([in] IInspectable* value);
 	}
 
-	[contract(Windows.Foundation.UniversalApiContract, 1.0)]
+	[contract(ClipboardContract, 1.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataRequest)]
 	[uuid(4341AE3B-FC12-4E53-8C02-AC714C415A27)]
 	interface IDataRequest : IInspectable
@@ -507,7 +509,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 		HRESULT GetDeferral([out] [retval] Microsoft.ProjectReunion.ApplicationModel.DataRequestDeferral** value);
 	}
 
-	[contract(Windows.Foundation.UniversalApiContract, 1.0)]
+	[contract(ClipboardContract, 1.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataRequestDeferral)]
 	[uuid(6DC4B89F-0386-4263-87C1-ED7DCE30890E)]
 	interface IDataRequestDeferral : IInspectable
@@ -515,7 +517,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 		HRESULT Complete();
 	}
 
-	[contract(Windows.Foundation.UniversalApiContract, 1.0)]
+	[contract(ClipboardContract, 1.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataRequestedEventArgs)]
 	[uuid(CB8BA807-6AC5-43C9-8AC5-9BA232163182)]
 	interface IDataRequestedEventArgs : IInspectable
@@ -523,7 +525,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 		[propget] HRESULT Request([out] [retval] Microsoft.ProjectReunion.ApplicationModel.DataRequest** value);
 	}
 
-	[contract(Windows.Foundation.UniversalApiContract, 1.0)]
+	[contract(ClipboardContract, 1.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataTransferManager)]
 	[uuid(A5CAEE9B-8708-49D1-8D36-67D25A8DA00C)]
 	interface IDataTransferManager : IInspectable
@@ -534,7 +536,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 		[eventremove] HRESULT TargetApplicationChosen([in] EventRegistrationToken eventCookie);
 	}
 
-	[contract(Windows.Foundation.UniversalApiContract, 4.0)]
+	[contract(ClipboardContract, 4.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataTransferManager)]
 	[uuid(30AE7D71-8BA8-4C02-8E3F-DDB23B388715)]
 	interface IDataTransferManager2 : IInspectable
@@ -543,7 +545,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 		[eventremove] HRESULT ShareProvidersRequested([in] EventRegistrationToken token);
 	}
 
-	[contract(Windows.Foundation.UniversalApiContract, 1.0)]
+	[contract(ClipboardContract, 1.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataTransferManager)]
 	[uuid(A9DA01AA-E00E-4CFE-AA44-2DD932DCA3D8)]
 	interface IDataTransferManagerStatics : IInspectable
@@ -552,7 +554,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 		HRESULT GetForCurrentView([out] [retval] Microsoft.ProjectReunion.ApplicationModel.DataTransferManager** value);
 	}
 
-	[contract(Windows.Foundation.UniversalApiContract, 3.0)]
+	[contract(ClipboardContract, 3.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataTransferManager)]
 	[uuid(C54EC2EC-9F97-4D63-9868-395E271AD8F5)]
 	interface IDataTransferManagerStatics2 : IInspectable
@@ -560,7 +562,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 		HRESULT IsSupported([out] [retval] boolean* value);
 	}
 
-	[contract(Windows.Foundation.UniversalApiContract, 5.0)]
+	[contract(ClipboardContract, 5.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataTransferManager)]
 	[uuid(05845473-6C82-4F5C-AC23-62E458361FAC)]
 	interface IDataTransferManagerStatics3 : IInspectable
@@ -568,7 +570,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 		[overload("ShowShareUI")] HRESULT ShowShareUIWithOptions([in] Microsoft.ProjectReunion.ApplicationModel.ShareUIOptions* options);
 	}
 
-	[contract(Windows.Foundation.UniversalApiContract, 1.0)]
+	[contract(ClipboardContract, 1.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.HtmlFormatHelper)]
 	[uuid(E22E7749-DD70-446F-AEFC-61CEE59F655E)]
 	interface IHtmlFormatHelperStatics : IInspectable
@@ -577,7 +579,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 		HRESULT CreateHtmlFormat([in] HSTRING htmlFragment, [out] [retval] HSTRING* htmlFormat);
 	}
 
-	[contract(Windows.Foundation.UniversalApiContract, 1.0)]
+	[contract(ClipboardContract, 1.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.OperationCompletedEventArgs)]
 	[uuid(E7AF329D-051D-4FAB-B1A9-47FD77F70A41)]
 	interface IOperationCompletedEventArgs : IInspectable
@@ -585,7 +587,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 		[propget] HRESULT Operation([out] [retval] Microsoft.ProjectReunion.ApplicationModel.DataPackageOperation* value);
 	}
 
-	[contract(Windows.Foundation.UniversalApiContract, 2.0)]
+	[contract(ClipboardContract, 2.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.OperationCompletedEventArgs)]
 	[uuid(858FA073-1E19-4105-B2F7-C8478808D562)]
 	interface IOperationCompletedEventArgs2 : IInspectable
@@ -593,7 +595,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 		[propget] HRESULT AcceptedFormatId([out] [retval] HSTRING* value);
 	}
 
-	[contract(Windows.Foundation.UniversalApiContract, 4.0)]
+	[contract(ClipboardContract, 4.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.ShareCompletedEventArgs)]
 	[uuid(4574C442-F913-4F60-9DF7-CC4060AB1916)]
 	interface IShareCompletedEventArgs : IInspectable
@@ -601,7 +603,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 		[propget] HRESULT ShareTarget([out] [retval] Microsoft.ProjectReunion.ApplicationModel.ShareTargetInfo** value);
 	}
 
-	[contract(Windows.Foundation.UniversalApiContract, 4.0)]
+	[contract(ClipboardContract, 4.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.ShareProvider)]
 	[uuid(2FABE026-443E-4CDA-AF25-8D81070EFD80)]
 	interface IShareProvider : IInspectable
@@ -613,7 +615,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 		[propput] HRESULT Tag([in] IInspectable* value);
 	}
 
-	[contract(Windows.Foundation.UniversalApiContract, 4.0)]
+	[contract(ClipboardContract, 4.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.ShareProvider)]
 	[uuid(172A174C-E79E-4F6D-B07D-128F469E0296)]
 	interface IShareProviderFactory : IInspectable
@@ -621,7 +623,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 		HRESULT Create([in] HSTRING title, [in] Windows.Storage.Streams.RandomAccessStreamReference* displayIcon, [in] Windows.UI.Color backgroundColor, [in] Microsoft.ProjectReunion.ApplicationModel.ShareProviderHandler* handler, [out] [retval] Microsoft.ProjectReunion.ApplicationModel.ShareProvider** result);
 	}
 
-	[contract(Windows.Foundation.UniversalApiContract, 4.0)]
+	[contract(ClipboardContract, 4.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.ShareProviderOperation)]
 	[uuid(19CEF937-D435-4179-B6AF-14E0492B69F6)]
 	interface IShareProviderOperation : IInspectable
@@ -631,7 +633,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 		HRESULT ReportCompleted();
 	}
 
-	[contract(Windows.Foundation.UniversalApiContract, 4.0)]
+	[contract(ClipboardContract, 4.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.ShareProvidersRequestedEventArgs)]
 	[uuid(F888F356-A3F8-4FCE-85E4-8826E63BE799)]
 	interface IShareProvidersRequestedEventArgs : IInspectable
@@ -641,7 +643,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 		HRESULT GetDeferral([out] [retval] Windows.Foundation.Deferral** value);
 	}
 
-	[contract(Windows.Foundation.UniversalApiContract, 4.0)]
+	[contract(ClipboardContract, 4.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.ShareTargetInfo)]
 	[uuid(385BE607-C6E8-4114-B294-28F3BB6F9904)]
 	interface IShareTargetInfo : IInspectable
@@ -650,7 +652,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 		[propget] HRESULT ShareProvider([out] [retval] Microsoft.ProjectReunion.ApplicationModel.ShareProvider** value);
 	}
 
-	[contract(Windows.Foundation.UniversalApiContract, 5.0)]
+	[contract(ClipboardContract, 5.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.ShareUIOptions)]
 	[uuid(72FA8A80-342F-4D90-9551-2AE04E37680C)]
 	interface IShareUIOptions : IInspectable
@@ -661,7 +663,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 		[propput] HRESULT SelectionRect([in] Windows.Foundation.IReference<Windows.Foundation.Rect>* value);
 	}
 
-	[contract(Windows.Foundation.UniversalApiContract, 1.0)]
+	[contract(ClipboardContract, 1.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.SharedStorageAccessManager)]
 	[uuid(C6132ADA-34B1-4849-BD5F-D09FEE3158C5)]
 	interface ISharedStorageAccessManagerStatics : IInspectable
@@ -671,20 +673,20 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 		HRESULT RemoveFile([in] HSTRING token);
 	}
 
-	[contract(Windows.Foundation.UniversalApiContract, 1.0)]
+	[contract(ClipboardContract, 1.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.StandardDataFormats)]
 	[uuid(7ED681A1-A880-40C9-B4ED-0BEE1E15F549)]
 	interface IStandardDataFormatsStatics : IInspectable
 	{
 		[propget] HRESULT Text([out] [retval] HSTRING* value);
-		[deprecated("Uri may be altered or unavailable for releases after Windows Phone 'OSVersion' (TBD). Instead, use WebLink or ApplicationLink.", deprecate, Windows.Foundation.UniversalApiContract, 1.0)] [propget] HRESULT Uri([out] [retval] HSTRING* value);
+		[deprecated("Uri may be altered or unavailable for releases after Windows Phone 'OSVersion' (TBD). Instead, use WebLink or ApplicationLink.", deprecate, ClipboardContract, 1.0)] [propget] HRESULT Uri([out] [retval] HSTRING* value);
 		[propget] HRESULT Html([out] [retval] HSTRING* value);
 		[propget] HRESULT Rtf([out] [retval] HSTRING* value);
 		[propget] HRESULT Bitmap([out] [retval] HSTRING* value);
 		[propget] HRESULT StorageItems([out] [retval] HSTRING* value);
 	}
 
-	[contract(Windows.Foundation.UniversalApiContract, 1.0)]
+	[contract(ClipboardContract, 1.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.StandardDataFormats)]
 	[uuid(42A254F4-9D76-42E8-861B-47C25DD0CF71)]
 	interface IStandardDataFormatsStatics2 : IInspectable
@@ -693,7 +695,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 		[propget] HRESULT ApplicationLink([out] [retval] HSTRING* value);
 	}
 
-	[contract(Windows.Foundation.UniversalApiContract, 6.0)]
+	[contract(ClipboardContract, 6.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.StandardDataFormats)]
 	[uuid(3B57B069-01D4-474C-8B5F-BC8E27F38B21)]
 	interface IStandardDataFormatsStatics3 : IInspectable
@@ -701,7 +703,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 		[propget] HRESULT UserActivityJsonArray([out] [retval] HSTRING* value);
 	}
 
-	[contract(Windows.Foundation.UniversalApiContract, 1.0)]
+	[contract(ClipboardContract, 1.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.TargetApplicationChosenEventArgs)]
 	[uuid(CA6FB8AC-2987-4EE3-9C54-D8AFBCB86C1D)]
 	interface ITargetApplicationChosenEventArgs : IInspectable
@@ -709,17 +711,17 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 		[propget] HRESULT ApplicationName([out] [retval] HSTRING* value);
 	}
 
-	[contract(Windows.Foundation.UniversalApiContract, 1.0)]
+	[contract(ClipboardContract, 1.0)]
 	[marshaling_behavior(standard)]
-	[static(Microsoft.ProjectReunion.ApplicationModel.IClipboardStatics, Windows.Foundation.UniversalApiContract, 1.0)]
-	[static(Microsoft.ProjectReunion.ApplicationModel.IClipboardStatics2, Windows.Foundation.UniversalApiContract, 7.0)]
+	[static(Microsoft.ProjectReunion.ApplicationModel.IClipboardStatics, ClipboardContract, 1.0)]
+	[static(Microsoft.ProjectReunion.ApplicationModel.IClipboardStatics2, ClipboardContract, 7.0)]
 	[threading(both)]
 	runtimeclass Clipboard
 	{
 	}
 
-	[activatable(Windows.Foundation.UniversalApiContract, 7.0)]
-	[contract(Windows.Foundation.UniversalApiContract, 7.0)]
+	[activatable(ClipboardContract, 7.0)]
+	[contract(ClipboardContract, 7.0)]
 	[marshaling_behavior(agile)]
 	[threading(both)]
 	runtimeclass ClipboardContentOptions
@@ -727,173 +729,173 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 		[default] interface Microsoft.ProjectReunion.ApplicationModel.IClipboardContentOptions;
 	}
 
-	[contract(Windows.Foundation.UniversalApiContract, 7.0)]
+	[contract(ClipboardContract, 7.0)]
 	[marshaling_behavior(agile)]
 	runtimeclass ClipboardHistoryChangedEventArgs
 	{
 		[default] interface Microsoft.ProjectReunion.ApplicationModel.IClipboardHistoryChangedEventArgs;
 	}
 
-	[contract(Windows.Foundation.UniversalApiContract, 7.0)]
+	[contract(ClipboardContract, 7.0)]
 	[marshaling_behavior(agile)]
 	runtimeclass ClipboardHistoryItem
 	{
 		[default] interface Microsoft.ProjectReunion.ApplicationModel.IClipboardHistoryItem;
 	}
 
-	[contract(Windows.Foundation.UniversalApiContract, 7.0)]
+	[contract(ClipboardContract, 7.0)]
 	[marshaling_behavior(agile)]
 	runtimeclass ClipboardHistoryItemsResult
 	{
 		[default] interface Microsoft.ProjectReunion.ApplicationModel.IClipboardHistoryItemsResult;
 	}
 
-	[activatable(Windows.Foundation.UniversalApiContract, 1.0)]
-	[contract(Windows.Foundation.UniversalApiContract, 1.0)]
+	[activatable(ClipboardContract, 1.0)]
+	[contract(ClipboardContract, 1.0)]
 	[marshaling_behavior(agile)]
 	[threading(both)]
 	runtimeclass DataPackage
 	{
 		[default] interface Microsoft.ProjectReunion.ApplicationModel.IDataPackage;
-		[contract(Windows.Foundation.UniversalApiContract, 1.0)] interface Microsoft.ProjectReunion.ApplicationModel.IDataPackage2;
-		[contract(Windows.Foundation.UniversalApiContract, 4.0)] interface Microsoft.ProjectReunion.ApplicationModel.IDataPackage3;
-		[contract(Windows.Foundation.UniversalApiContract, 10.0)] interface Microsoft.ProjectReunion.ApplicationModel.IDataPackage4;
+		[contract(ClipboardContract, 1.0)] interface Microsoft.ProjectReunion.ApplicationModel.IDataPackage2;
+		[contract(ClipboardContract, 4.0)] interface Microsoft.ProjectReunion.ApplicationModel.IDataPackage3;
+		[contract(ClipboardContract, 10.0)] interface Microsoft.ProjectReunion.ApplicationModel.IDataPackage4;
 	}
 
-	[contract(Windows.Foundation.UniversalApiContract, 1.0)]
+	[contract(ClipboardContract, 1.0)]
 	[marshaling_behavior(agile)]
 	runtimeclass DataPackagePropertySet
 	{
 		[default] interface Microsoft.ProjectReunion.ApplicationModel.IDataPackagePropertySet;
 		interface Windows.Foundation.Collections.IMap<HSTRING, IInspectable*>;
 		interface Windows.Foundation.Collections.IIterable<Windows.Foundation.Collections.IKeyValuePair<HSTRING, IInspectable*>*>;
-		[contract(Windows.Foundation.UniversalApiContract, 1.0)] interface Microsoft.ProjectReunion.ApplicationModel.IDataPackagePropertySet2;
-		[contract(Windows.Foundation.UniversalApiContract, 1.0)] interface Microsoft.ProjectReunion.ApplicationModel.IDataPackagePropertySet3;
-		[contract(Windows.Foundation.UniversalApiContract, 6.0)] interface Microsoft.ProjectReunion.ApplicationModel.IDataPackagePropertySet4;
+		[contract(ClipboardContract, 1.0)] interface Microsoft.ProjectReunion.ApplicationModel.IDataPackagePropertySet2;
+		[contract(ClipboardContract, 1.0)] interface Microsoft.ProjectReunion.ApplicationModel.IDataPackagePropertySet3;
+		[contract(ClipboardContract, 6.0)] interface Microsoft.ProjectReunion.ApplicationModel.IDataPackagePropertySet4;
 	}
 
-	[contract(Windows.Foundation.UniversalApiContract, 1.0)]
+	[contract(ClipboardContract, 1.0)]
 	[marshaling_behavior(agile)]
 	runtimeclass DataPackagePropertySetView
 	{
 		[default] interface Microsoft.ProjectReunion.ApplicationModel.IDataPackagePropertySetView;
-		[contract(Windows.Foundation.UniversalApiContract, 1.0)] interface Microsoft.ProjectReunion.ApplicationModel.IDataPackagePropertySetView2;
-		[contract(Windows.Foundation.UniversalApiContract, 1.0)] interface Microsoft.ProjectReunion.ApplicationModel.IDataPackagePropertySetView3;
-		[contract(Windows.Foundation.UniversalApiContract, 6.0)] interface Microsoft.ProjectReunion.ApplicationModel.IDataPackagePropertySetView4;
-		[contract(Windows.Foundation.UniversalApiContract, 7.0)] interface Microsoft.ProjectReunion.ApplicationModel.IDataPackagePropertySetView5;
+		[contract(ClipboardContract, 1.0)] interface Microsoft.ProjectReunion.ApplicationModel.IDataPackagePropertySetView2;
+		[contract(ClipboardContract, 1.0)] interface Microsoft.ProjectReunion.ApplicationModel.IDataPackagePropertySetView3;
+		[contract(ClipboardContract, 6.0)] interface Microsoft.ProjectReunion.ApplicationModel.IDataPackagePropertySetView4;
+		[contract(ClipboardContract, 7.0)] interface Microsoft.ProjectReunion.ApplicationModel.IDataPackagePropertySetView5;
 		interface Windows.Foundation.Collections.IMapView<HSTRING, IInspectable*>;
 		interface Windows.Foundation.Collections.IIterable<Windows.Foundation.Collections.IKeyValuePair<HSTRING, IInspectable*>*>;
 	}
 
-	[contract(Windows.Foundation.UniversalApiContract, 1.0)]
+	[contract(ClipboardContract, 1.0)]
 	[marshaling_behavior(agile)]
 	runtimeclass DataPackageView
 	{
 		[default] interface Microsoft.ProjectReunion.ApplicationModel.IDataPackageView;
-		[contract(Windows.Foundation.UniversalApiContract, 1.0)] interface Microsoft.ProjectReunion.ApplicationModel.IDataPackageView2;
-		[contract(Windows.Foundation.UniversalApiContract, 1.0)] interface Microsoft.ProjectReunion.ApplicationModel.IDataPackageView3;
-		[contract(Windows.Foundation.UniversalApiContract, 2.0)] interface Microsoft.ProjectReunion.ApplicationModel.IDataPackageView4;
+		[contract(ClipboardContract, 1.0)] interface Microsoft.ProjectReunion.ApplicationModel.IDataPackageView2;
+		[contract(ClipboardContract, 1.0)] interface Microsoft.ProjectReunion.ApplicationModel.IDataPackageView3;
+		[contract(ClipboardContract, 2.0)] interface Microsoft.ProjectReunion.ApplicationModel.IDataPackageView4;
 	}
 
-	[contract(Windows.Foundation.UniversalApiContract, 1.0)]
+	[contract(ClipboardContract, 1.0)]
 	[marshaling_behavior(agile)]
 	runtimeclass DataProviderDeferral
 	{
 		[default] interface Microsoft.ProjectReunion.ApplicationModel.IDataProviderDeferral;
 	}
 
-	[contract(Windows.Foundation.UniversalApiContract, 1.0)]
+	[contract(ClipboardContract, 1.0)]
 	[marshaling_behavior(agile)]
 	runtimeclass DataProviderRequest
 	{
 		[default] interface Microsoft.ProjectReunion.ApplicationModel.IDataProviderRequest;
 	}
 
-	[contract(Windows.Foundation.UniversalApiContract, 1.0)]
+	[contract(ClipboardContract, 1.0)]
 	[marshaling_behavior(agile)]
 	runtimeclass DataRequest
 	{
 		[default] interface Microsoft.ProjectReunion.ApplicationModel.IDataRequest;
 	}
 
-	[contract(Windows.Foundation.UniversalApiContract, 1.0)]
+	[contract(ClipboardContract, 1.0)]
 	[marshaling_behavior(agile)]
 	runtimeclass DataRequestDeferral
 	{
 		[default] interface Microsoft.ProjectReunion.ApplicationModel.IDataRequestDeferral;
 	}
 
-	[contract(Windows.Foundation.UniversalApiContract, 1.0)]
+	[contract(ClipboardContract, 1.0)]
 	[marshaling_behavior(agile)]
 	runtimeclass DataRequestedEventArgs
 	{
 		[default] interface Microsoft.ProjectReunion.ApplicationModel.IDataRequestedEventArgs;
 	}
 
-	[contract(Windows.Foundation.UniversalApiContract, 1.0)]
+	[contract(ClipboardContract, 1.0)]
 	[marshaling_behavior(standard)]
-	[static(Microsoft.ProjectReunion.ApplicationModel.IDataTransferManagerStatics, Windows.Foundation.UniversalApiContract, 1.0)]
-	[static(Microsoft.ProjectReunion.ApplicationModel.IDataTransferManagerStatics2, Windows.Foundation.UniversalApiContract, 3.0)]
-	[static(Microsoft.ProjectReunion.ApplicationModel.IDataTransferManagerStatics3, Windows.Foundation.UniversalApiContract, 5.0)]
+	[static(Microsoft.ProjectReunion.ApplicationModel.IDataTransferManagerStatics, ClipboardContract, 1.0)]
+	[static(Microsoft.ProjectReunion.ApplicationModel.IDataTransferManagerStatics2, ClipboardContract, 3.0)]
+	[static(Microsoft.ProjectReunion.ApplicationModel.IDataTransferManagerStatics3, ClipboardContract, 5.0)]
 	runtimeclass DataTransferManager
 	{
 		[default] interface Microsoft.ProjectReunion.ApplicationModel.IDataTransferManager;
-		[contract(Windows.Foundation.UniversalApiContract, 4.0)] interface Microsoft.ProjectReunion.ApplicationModel.IDataTransferManager2;
+		[contract(ClipboardContract, 4.0)] interface Microsoft.ProjectReunion.ApplicationModel.IDataTransferManager2;
 	}
 
-	[contract(Windows.Foundation.UniversalApiContract, 1.0)]
+	[contract(ClipboardContract, 1.0)]
 	[marshaling_behavior(agile)]
-	[static(Microsoft.ProjectReunion.ApplicationModel.IHtmlFormatHelperStatics, Windows.Foundation.UniversalApiContract, 1.0)]
+	[static(Microsoft.ProjectReunion.ApplicationModel.IHtmlFormatHelperStatics, ClipboardContract, 1.0)]
 	runtimeclass HtmlFormatHelper
 	{
 	}
 
-	[contract(Windows.Foundation.UniversalApiContract, 1.0)]
+	[contract(ClipboardContract, 1.0)]
 	[marshaling_behavior(agile)]
 	runtimeclass OperationCompletedEventArgs
 	{
 		[default] interface Microsoft.ProjectReunion.ApplicationModel.IOperationCompletedEventArgs;
-		[contract(Windows.Foundation.UniversalApiContract, 2.0)] interface Microsoft.ProjectReunion.ApplicationModel.IOperationCompletedEventArgs2;
+		[contract(ClipboardContract, 2.0)] interface Microsoft.ProjectReunion.ApplicationModel.IOperationCompletedEventArgs2;
 	}
 
-	[contract(Windows.Foundation.UniversalApiContract, 4.0)]
+	[contract(ClipboardContract, 4.0)]
 	[marshaling_behavior(agile)]
 	runtimeclass ShareCompletedEventArgs
 	{
 		[default] interface Microsoft.ProjectReunion.ApplicationModel.IShareCompletedEventArgs;
 	}
 
-	[activatable(Microsoft.ProjectReunion.ApplicationModel.IShareProviderFactory, Windows.Foundation.UniversalApiContract, 4.0)]
-	[contract(Windows.Foundation.UniversalApiContract, 4.0)]
+	[activatable(Microsoft.ProjectReunion.ApplicationModel.IShareProviderFactory, ClipboardContract, 4.0)]
+	[contract(ClipboardContract, 4.0)]
 	[marshaling_behavior(agile)]
 	runtimeclass ShareProvider
 	{
 		[default] interface Microsoft.ProjectReunion.ApplicationModel.IShareProvider;
 	}
 
-	[contract(Windows.Foundation.UniversalApiContract, 4.0)]
+	[contract(ClipboardContract, 4.0)]
 	[marshaling_behavior(agile)]
 	runtimeclass ShareProviderOperation
 	{
 		[default] interface Microsoft.ProjectReunion.ApplicationModel.IShareProviderOperation;
 	}
 
-	[contract(Windows.Foundation.UniversalApiContract, 4.0)]
+	[contract(ClipboardContract, 4.0)]
 	[marshaling_behavior(agile)]
 	runtimeclass ShareProvidersRequestedEventArgs
 	{
 		[default] interface Microsoft.ProjectReunion.ApplicationModel.IShareProvidersRequestedEventArgs;
 	}
 
-	[contract(Windows.Foundation.UniversalApiContract, 4.0)]
+	[contract(ClipboardContract, 4.0)]
 	[marshaling_behavior(agile)]
 	runtimeclass ShareTargetInfo
 	{
 		[default] interface Microsoft.ProjectReunion.ApplicationModel.IShareTargetInfo;
 	}
 
-	[activatable(Windows.Foundation.UniversalApiContract, 5.0)]
-	[contract(Windows.Foundation.UniversalApiContract, 5.0)]
+	[activatable(ClipboardContract, 5.0)]
+	[contract(ClipboardContract, 5.0)]
 	[marshaling_behavior(agile)]
 	[threading(both)]
 	runtimeclass ShareUIOptions
@@ -901,22 +903,22 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 		[default] interface Microsoft.ProjectReunion.ApplicationModel.IShareUIOptions;
 	}
 
-	[contract(Windows.Foundation.UniversalApiContract, 1.0)]
-	[static(Microsoft.ProjectReunion.ApplicationModel.ISharedStorageAccessManagerStatics, Windows.Foundation.UniversalApiContract, 1.0)]
+	[contract(ClipboardContract, 1.0)]
+	[static(Microsoft.ProjectReunion.ApplicationModel.ISharedStorageAccessManagerStatics, ClipboardContract, 1.0)]
 	runtimeclass SharedStorageAccessManager
 	{
 	}
 
-	[contract(Windows.Foundation.UniversalApiContract, 1.0)]
+	[contract(ClipboardContract, 1.0)]
 	[marshaling_behavior(agile)]
-	[static(Microsoft.ProjectReunion.ApplicationModel.IStandardDataFormatsStatics, Windows.Foundation.UniversalApiContract, 1.0)]
-	[static(Microsoft.ProjectReunion.ApplicationModel.IStandardDataFormatsStatics2, Windows.Foundation.UniversalApiContract, 1.0)]
-	[static(Microsoft.ProjectReunion.ApplicationModel.IStandardDataFormatsStatics3, Windows.Foundation.UniversalApiContract, 6.0)]
+	[static(Microsoft.ProjectReunion.ApplicationModel.IStandardDataFormatsStatics, ClipboardContract, 1.0)]
+	[static(Microsoft.ProjectReunion.ApplicationModel.IStandardDataFormatsStatics2, ClipboardContract, 1.0)]
+	[static(Microsoft.ProjectReunion.ApplicationModel.IStandardDataFormatsStatics3, ClipboardContract, 6.0)]
 	runtimeclass StandardDataFormats
 	{
 	}
 
-	[contract(Windows.Foundation.UniversalApiContract, 1.0)]
+	[contract(ClipboardContract, 1.0)]
 	[marshaling_behavior(agile)]
 	runtimeclass TargetApplicationChosenEventArgs
 	{

--- a/specs/clipboard-api/clipboard.idl
+++ b/specs/clipboard-api/clipboard.idl
@@ -145,7 +145,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
   /// includes clipboard items roamed from your other devices through the cloud.
   /// </summary>
   [contract(ClipboardContract, 1.0)]
-  [static_name("Microsoft.ProjectReunion.ApplicationModel.IClipboardStatics", 6cb53030-4da0-43a1-95ab-52f87cf59c3a)]
+  [static_name("IClipboardStatics", 6cb53030-4da0-43a1-95ab-52f87cf59c3a)]
   [marshaling_behavior(standard)]
   static runtimeclass Clipboard
   {
@@ -175,7 +175,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
   /// Settings your app can set for a new item it cuts or copies onto the clipboard.
   /// </summary>
   [contract(ClipboardContract, 1.0)]
-  [interface_name("Microsoft.ProjectReunion.ApplicationModel.IClipboardContentOptions", c31b927f-1008-4e98-b575-adf175ccdd0b)]
+  [interface_name("IClipboardContentOptions", c31b927f-1008-4e98-b575-adf175ccdd0b)]
   runtimeclass ClipboardContentOptions
   {
     ClipboardContentOptions();
@@ -191,7 +191,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
   /// </summary>
   // TO CONSIDER: should this class be omitted since it was empty in-box?
   [contract(ClipboardContract, 1.0)]
-  [interface_name("Microsoft.ProjectReunion.ApplicationModel.IClipboardHistoryChangedEventArgs", 9d1960c7-cf0a-4e51-943c-72373b7a2579)]
+  [interface_name("IClipboardHistoryChangedEventArgs", 9d1960c7-cf0a-4e51-943c-72373b7a2579)]
   runtimeclass ClipboardHistoryChangedEventArgs
   { }
 
@@ -199,7 +199,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
   /// An item retrieved from the clipboard history log.
   /// </summary>
   [contract(ClipboardContract, 1.0)]
-  [interface_name("Microsoft.ProjectReunion.ApplicationModel.IClipboardHistoryItem", 1907eff8-7d2f-4a71-8a56-bd02effeb184)]
+  [interface_name("IClipboardHistoryItem", 1907eff8-7d2f-4a71-8a56-bd02effeb184)]
   runtimeclass ClipboardHistoryItem
   {
     String Id { get; };
@@ -211,7 +211,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
   /// Return value for a call to <see cref="Clipboard.GetHistoryItemsAsync"/>.
   /// </summary>
   [contract(ClipboardContract, 1.0)]
-  [interface_name("Microsoft.ProjectReunion.ApplicationModel.IClipboardHistoryItemsResult", 2f6c9705-f56b-42f0-b1a1-fc2d46d572e7)]
+  [interface_name("IClipboardHistoryItemsResult", 2f6c9705-f56b-42f0-b1a1-fc2d46d572e7)]
   runtimeclass ClipboardHistoryItemsResult
   {
     ClipboardHistoryItemsResultStatus Status { get; };
@@ -226,7 +226,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
   /// serialize them on demand.
   /// </summary>
   [contract(ClipboardContract, 1.0)]
-  [interface_name("Microsoft.ProjectReunion.ApplicationModel.IDataPackage", 36861532-b01e-49c5-9a0b-2282d079c9ac)]
+  [interface_name("IDataPackage", 36861532-b01e-49c5-9a0b-2282d079c9ac)]
   runtimeclass DataPackage
   {
     DataPackage();
@@ -260,7 +260,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
   /// Read-only view of a <see cref="DataPackage"/>.
   /// </summary>
   [contract(ClipboardContract, 1.0)]
-  [interface_name("Microsoft.ProjectReunion.ApplicationModel.IDataPackageView", 659f7a31-3335-4e57-b373-8898ffae5ab1)]
+  [interface_name("IDataPackageView", 659f7a31-3335-4e57-b373-8898ffae5ab1)]
   runtimeclass DataPackageView
   {
     DataPackagePropertySetView Properties { get; };
@@ -378,7 +378,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
   /// a delay rendering, with the ability to signal the system when done.
   /// </summary>
   [contract(ClipboardContract, 1.0)]
-  [interface_name("Microsoft.ProjectReunion.ApplicationModel.IDataProviderDeferral", 4f9a822c-1bb1-4c3e-b908-e202c8b87f4c)]
+  [interface_name("IDataProviderDeferral", 4f9a822c-1bb1-4c3e-b908-e202c8b87f4c)]
   runtimeclass DataProviderDeferral
   {
     void Complete();
@@ -388,7 +388,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
   /// Input to a <see cref="DataProviderHandler"/> function for delay-rendering.
   /// </summary>
   [contract(ClipboardContract, 1.0)]
-  [interface_name("Microsoft.ProjectReunion.ApplicationModel.IDataProviderRequest", 25f2c71c-832b-4b8e-b9e9-672f098d2770)]
+  [interface_name("IDataProviderRequest", 25f2c71c-832b-4b8e-b9e9-672f098d2770)]
   runtimeclass DataProviderRequest
   {
     String FormatId { get; };
@@ -402,7 +402,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
   /// used by <see cref="StandardDataFormats.Html"/>, described here:
   /// https://docs.microsoft.com/windows/win32/dataxchg/html-clipboard-format
   /// </summary>
-  [static_name("Microsoft.ProjectReunion.ApplicationModel.IHtmlFormatHelperStatics", cce26a46-4048-4fb4-99c8-b822d03cd526)]
+  [static_name("IHtmlFormatHelperStatics", cce26a46-4048-4fb4-99c8-b822d03cd526)]
   static runtimeclass HtmlFormatHelper
   {
     static String GetStaticFragment(String htmlFormat);
@@ -413,8 +413,9 @@ namespace Microsoft.ProjectReunion.ApplicationModel
   /// Input parameters for <see cref="DataPackage.OperationCompleted"/> event handler functions.
   /// </summary>
   [contract(ClipboardContract, 1.0)]
-  [interface_name("Microsoft.ProjectReunion.ApplicationModel.IOperationCompletedEventArgs", a180ab74-fcc7-42f3-a6bd-5d373a28fc8d)]
+  [interface_name("IOperationCompletedEventArgs", a180ab74-fcc7-42f3-a6bd-5d373a28fc8d)]
   runtimeclass OperationCompletedEventArgs
+  // FIXME: since the namespace is now ApplicationModel, this name is too generic. Should rename?
   {
     DataPackageOperation Operation { get; };
 
@@ -426,7 +427,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
   /// to the <see cref="DataPackage"/> system.
   /// </summary>
   [contract(ClipboardContract, 1.0)]
-  [static_name("Microsoft.ProjectReunion.ApplicationModel.IStandardDataFormatsStatics", 18f4cbf8-64f1-4ba1-9e64-53648a0443a8)]
+  [static_name("IStandardDataFormatsStatics", 18f4cbf8-64f1-4ba1-9e64-53648a0443a8)]
   static runtimeclass StandardDataFormats
   {
     static String Text { get; };

--- a/specs/clipboard-api/clipboard.idl
+++ b/specs/clipboard-api/clipboard.idl
@@ -160,50 +160,50 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 	[contract(ClipboardContract, 7.0)]
 	enum ClipboardHistoryItemsResultStatus
 	{
-		Success                  = 0,
-		AccessDenied             = 1,
-		ClipboardHistoryDisabled = 2
+		aaaSuccess                  = 0,
+		aaaAccessDenied             = 1,
+		aaaClipboardHistoryDisabled = 2
 	};
 
 	[contract(ClipboardContract, 1.0)]
 	[flags]
 	enum DataPackageOperation
 	{
-		None = 0x0,
-		Copy = 0x1,
-		Move = 0x2,
-		Link = 0x4
+		aaaNone = 0x0,
+		aaaCopy = 0x1,
+		aaaMove = 0x2,
+		aaaLink = 0x4
 	};
 
 	[contract(ClipboardContract, 7.0)]
 	enum SetHistoryItemAsContentStatus
 	{
-		Success      = 0,
-		AccessDenied = 1,
-		ItemDeleted  = 2
+		aaaSuccess      = 0,
+		aaaAccessDenied = 1,
+		aaaItemDeleted  = 2
 	};
 
 	[contract(ClipboardContract, 5.0)]
 	enum ShareUITheme
 	{
-		Default = 0,
-		Light   = 1,
-		Dark    = 2
+		aaaDefault = 0,
+		aaaLight   = 1,
+		aaaDark    = 2
 	};
 
 	[contract(ClipboardContract, 1.0)]
-	[uuid(E7ECD720-F2F4-4A2D-920E-170A2F482A27)]
+	[uuid(6d9e7bfb-3280-4219-be29-08145f30f4e5)]
 	delegate
 		HRESULT DataProviderHandler([in] Microsoft.ProjectReunion.ApplicationModel.DataProviderRequest* request);
 
 	[contract(ClipboardContract, 4.0)]
-	[uuid(E7F9D9BA-E1BA-4E4D-BD65-D43845D3212F)]
+	[uuid(0d89ad1d-bb56-43e0-89d3-df5f85af2dd6)]
 	delegate
 		HRESULT ShareProviderHandler([in] Microsoft.ProjectReunion.ApplicationModel.ShareProviderOperation* operation);
 
 	[contract(ClipboardContract, 7.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.ClipboardContentOptions)]
-	[uuid(E888A98C-AD4B-5447-A056-AB3556276D2B)]
+	[uuid(c31b927f-1008-4e98-b575-adf175ccdd0b)]
 	interface IClipboardContentOptions : IInspectable
 	{
 		[propget] HRESULT IsRoamable([out] [retval] boolean* value);
@@ -216,14 +216,14 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 
 	[contract(ClipboardContract, 7.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.ClipboardHistoryChangedEventArgs)]
-	[uuid(C0BE453F-8EA2-53CE-9ABA-8D2212573452)]
+	[uuid(9d1960c7-cf0a-4e51-943c-72373b7a2579)]
 	interface IClipboardHistoryChangedEventArgs : IInspectable
 	{
 	}
 
 	[contract(ClipboardContract, 7.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.ClipboardHistoryItem)]
-	[uuid(0173BD8A-AFFF-5C50-AB92-3D19F481EC58)]
+	[uuid(1907eff8-7d2f-4a71-8a56-bd02effeb184)]
 	interface IClipboardHistoryItem : IInspectable
 	{
 		[propget] HRESULT Id([out] [retval] HSTRING* value);
@@ -233,7 +233,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 
 	[contract(ClipboardContract, 7.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.ClipboardHistoryItemsResult)]
-	[uuid(E6DFDEE6-0EE2-52E3-852B-F295DB65939A)]
+	[uuid(2f6c9705-f56b-42f0-b1a1-fc2d46d572e7)]
 	interface IClipboardHistoryItemsResult : IInspectable
 	{
 		[propget] HRESULT Status([out] [retval] Microsoft.ProjectReunion.ApplicationModel.ClipboardHistoryItemsResultStatus* value);
@@ -242,7 +242,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 
 	[contract(ClipboardContract, 1.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.Clipboard)]
-	[uuid(C627E291-34E2-4963-8EED-93CBB0EA3D70)]
+	[uuid(6cb53030-4da0-43a1-95ab-52f87cf59c3a)]
 	interface IClipboardStatics : IInspectable
 	{
 		HRESULT GetContent([out] [retval] Microsoft.ProjectReunion.ApplicationModel.DataPackageView** result);
@@ -255,7 +255,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 
 	[contract(ClipboardContract, 7.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.Clipboard)]
-	[uuid(D2AC1B6A-D29F-554B-B303-F0452345FE02)]
+	[uuid(d6baf461-6fc5-4e51-a4b1-fb07b3a7a9e0)]
 	interface IClipboardStatics2 : IInspectable
 	{
 		HRESULT GetHistoryItemsAsync([out] [retval] Windows.Foundation.IAsyncOperation<Microsoft.ProjectReunion.ApplicationModel.ClipboardHistoryItemsResult*>** operation);
@@ -275,7 +275,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 
 	[contract(ClipboardContract, 1.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataPackage)]
-	[uuid(61EBF5C7-EFEA-4346-9554-981D7E198FFE)]
+	[uuid(36861532-b01e-49c5-9a0b-2282d079c9ac)]
 	interface IDataPackage : IInspectable
 	{
 		HRESULT GetView([out] [retval] Microsoft.ProjectReunion.ApplicationModel.DataPackageView** result);
@@ -300,7 +300,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 
 	[contract(ClipboardContract, 1.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataPackage)]
-	[uuid(041C1FE9-2409-45E1-A538-4C53EEEE04A7)]
+	[uuid(9f8a2f2b-3602-48ec-b0dd-4d7f754da3b2)]
 	interface IDataPackage2 : IInspectable
 	{
 		HRESULT SetApplicationLink([in] Windows.Foundation.Uri* value);
@@ -309,7 +309,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 
 	[contract(ClipboardContract, 4.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataPackage)]
-	[uuid(88F31F5D-787B-4D32-965A-A9838105A056)]
+	[uuid(670dbf2f-9f0e-4ed9-a3f3-775fb0cd2134)]
 	interface IDataPackage3 : IInspectable
 	{
 		[eventadd] HRESULT ShareCompleted([in] Windows.Foundation.TypedEventHandler<Microsoft.ProjectReunion.ApplicationModel.DataPackage*, Microsoft.ProjectReunion.ApplicationModel.ShareCompletedEventArgs*>* handler, [out] [retval] EventRegistrationToken* token);
@@ -318,7 +318,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 
 	[contract(ClipboardContract, 10.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataPackage)]
-	[uuid(13A24EC8-9382-536F-852A-3045E1B29A3B)]
+	[uuid(fd923204-3d54-4fd2-b1fc-607984c97f43)]
 	interface IDataPackage4 : IInspectable
 	{
 		[eventadd] HRESULT ShareCanceled([in] Windows.Foundation.TypedEventHandler<Microsoft.ProjectReunion.ApplicationModel.DataPackage*, IInspectable*>* handler, [out] [retval] EventRegistrationToken* token);
@@ -327,7 +327,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 
 	[contract(ClipboardContract, 1.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataPackagePropertySet)]
-	[uuid(CD1C93EB-4C4C-443A-A8D3-F5C241E91689)]
+	[uuid(6c1bd5dd-d89e-4f79-ae3b-4ad565586202)]
 	interface IDataPackagePropertySet : IInspectable
 		requires
 			Windows.Foundation.Collections.IMap<HSTRING, IInspectable*>,
@@ -348,7 +348,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 
 	[contract(ClipboardContract, 1.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataPackagePropertySet)]
-	[uuid(EB505D4A-9800-46AA-B181-7B6F0F2B919A)]
+	[uuid(744e9c77-6463-4b99-b3c3-f69d9ee594bf)]
 	interface IDataPackagePropertySet2 : IInspectable
 	{
 		[propget] HRESULT ContentSourceWebLink([out] [retval] Windows.Foundation.Uri** value);
@@ -365,7 +365,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 
 	[contract(ClipboardContract, 1.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataPackagePropertySet)]
-	[uuid(9E87FD9B-5205-401B-874A-455653BD39E8)]
+	[uuid(c8c24a60-f4b3-4ab0-88e9-c23062e0cc33)]
 	interface IDataPackagePropertySet3 : IInspectable
 	{
 		[propget] HRESULT EnterpriseId([out] [retval] HSTRING* value);
@@ -374,7 +374,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 
 	[contract(ClipboardContract, 6.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataPackagePropertySet)]
-	[uuid(6390EBF5-1739-4C74-B22F-865FAB5E8545)]
+	[uuid(d1270af6-a2e8-4d31-b697-b48103d5a15a)]
 	interface IDataPackagePropertySet4 : IInspectable
 	{
 		[propget] HRESULT ContentSourceUserActivityJson([out] [retval] HSTRING* value);
@@ -383,7 +383,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 
 	[contract(ClipboardContract, 1.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataPackagePropertySetView)]
-	[uuid(B94CEC01-0C1A-4C57-BE55-75D01289735D)]
+	[uuid(054c0bc4-ca76-4e7d-9511-4322a5a0b58b)]
 	interface IDataPackagePropertySetView : IInspectable
 	{
 		[propget] HRESULT Title([out] [retval] HSTRING* value);
@@ -396,7 +396,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 
 	[contract(ClipboardContract, 1.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataPackagePropertySetView)]
-	[uuid(6054509B-8EBE-4FEB-9C1E-75E69DE54B84)]
+	[uuid(e35b2f0d-1c7a-4bf3-ab72-50554054d7b2)]
 	interface IDataPackagePropertySetView2 : IInspectable
 	{
 		[propget] HRESULT PackageFamilyName([out] [retval] HSTRING* value);
@@ -408,7 +408,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 
 	[contract(ClipboardContract, 1.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataPackagePropertySetView)]
-	[uuid(DB764CE5-D174-495C-84FC-1A51F6AB45D7)]
+	[uuid(52067bc5-0b4c-4559-8da1-cc75dc6f2344)]
 	interface IDataPackagePropertySetView3 : IInspectable
 	{
 		[propget] HRESULT EnterpriseId([out] [retval] HSTRING* value);
@@ -416,7 +416,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 
 	[contract(ClipboardContract, 6.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataPackagePropertySetView)]
-	[uuid(4474C80D-D16F-40AE-9580-6F8562B94235)]
+	[uuid(0e1a2836-c904-4e63-be50-d3f743864782)]
 	interface IDataPackagePropertySetView4 : IInspectable
 	{
 		[propget] HRESULT ContentSourceUserActivityJson([out] [retval] HSTRING* value);
@@ -424,7 +424,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 
 	[contract(ClipboardContract, 7.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataPackagePropertySetView)]
-	[uuid(6F0A9445-3760-50BB-8523-C4202DED7D78)]
+	[uuid(75ff681c-4bd4-4cfb-aede-9c3a7e6f245d)]
 	interface IDataPackagePropertySetView5 : IInspectable
 	{
 		[propget] HRESULT IsFromRoamingClipboard([out] [retval] boolean* value);
@@ -432,7 +432,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 
 	[contract(ClipboardContract, 1.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataPackageView)]
-	[uuid(7B840471-5900-4D85-A90B-10CB85FE3552)]
+	[uuid(659f7a31-3335-4e57-b373-8898ffae5ab1)]
 	interface IDataPackageView : IInspectable
 	{
 		[propget] HRESULT Properties([out] [retval] Microsoft.ProjectReunion.ApplicationModel.DataPackagePropertySetView** value);
@@ -453,7 +453,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 
 	[contract(ClipboardContract, 1.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataPackageView)]
-	[uuid(40ECBA95-2450-4C1D-B6B4-ED45463DEE9C)]
+	[uuid(a64648c4-fefb-48b4-a0b4-d9be5ac8233b)]
 	interface IDataPackageView2 : IInspectable
 	{
 		HRESULT GetApplicationLinkAsync([out] [retval] Windows.Foundation.IAsyncOperation<Windows.Foundation.Uri*>** operation);
@@ -462,7 +462,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 
 	[contract(ClipboardContract, 1.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataPackageView)]
-	[uuid(D37771A8-DDAD-4288-8428-D1CAE394128B)]
+	[uuid(9b0e47cd-8eef-485d-bdd1-d371e9cf2ebe)]
 	interface IDataPackageView3 : IInspectable
 	{
 		[overload("RequestAccessAsync")] HRESULT RequestAccessAsync([out] [retval] Windows.Foundation.IAsyncOperation<Windows.Security.EnterpriseData.ProtectionPolicyEvaluationResult>** operation);
@@ -472,7 +472,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 
 	[contract(ClipboardContract, 2.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataPackageView)]
-	[uuid(DFE96F1F-E042-4433-A09F-26D6FFDA8B85)]
+	[uuid(a56c7b9b-7865-4177-abf5-99412eb412a9)]
 	interface IDataPackageView4 : IInspectable
 	{
 		HRESULT SetAcceptedFormatId([in] HSTRING formatId);
@@ -480,7 +480,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 
 	[contract(ClipboardContract, 1.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataProviderDeferral)]
-	[uuid(C2CF2373-2D26-43D9-B69D-DCB86D03F6DA)]
+	[uuid(4f9a822c-1bb1-4c3e-b908-e202c8b87f4c)]
 	interface IDataProviderDeferral : IInspectable
 	{
 		HRESULT Complete();
@@ -488,7 +488,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 
 	[contract(ClipboardContract, 1.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataProviderRequest)]
-	[uuid(EBBC7157-D3C8-47DA-ACDE-F82388D5F716)]
+	[uuid(25f2c71c-832b-4b8e-b9e9-672f098d2770)]
 	interface IDataProviderRequest : IInspectable
 	{
 		[propget] HRESULT FormatId([out] [retval] HSTRING* value);
@@ -499,7 +499,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 
 	[contract(ClipboardContract, 1.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataRequest)]
-	[uuid(4341AE3B-FC12-4E53-8C02-AC714C415A27)]
+	[uuid(6a17e08b-8a32-484c-a07a-d416c04277cb)]
 	interface IDataRequest : IInspectable
 	{
 		[propget] HRESULT Data([out] [retval] Microsoft.ProjectReunion.ApplicationModel.DataPackage** value);
@@ -511,7 +511,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 
 	[contract(ClipboardContract, 1.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataRequestDeferral)]
-	[uuid(6DC4B89F-0386-4263-87C1-ED7DCE30890E)]
+	[uuid(dbb4bb17-24d4-45c7-b668-18b162942504)]
 	interface IDataRequestDeferral : IInspectable
 	{
 		HRESULT Complete();
@@ -519,7 +519,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 
 	[contract(ClipboardContract, 1.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataRequestedEventArgs)]
-	[uuid(CB8BA807-6AC5-43C9-8AC5-9BA232163182)]
+	[uuid(e169b0d1-224d-42e1-84b7-1851d72da4e0)]
 	interface IDataRequestedEventArgs : IInspectable
 	{
 		[propget] HRESULT Request([out] [retval] Microsoft.ProjectReunion.ApplicationModel.DataRequest** value);
@@ -527,7 +527,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 
 	[contract(ClipboardContract, 1.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataTransferManager)]
-	[uuid(A5CAEE9B-8708-49D1-8D36-67D25A8DA00C)]
+	[uuid(d55b10ac-e3c1-4b9d-ba05-e28056811f4b)]
 	interface IDataTransferManager : IInspectable
 	{
 		[eventadd] HRESULT DataRequested([in] Windows.Foundation.TypedEventHandler<Microsoft.ProjectReunion.ApplicationModel.DataTransferManager*, Microsoft.ProjectReunion.ApplicationModel.DataRequestedEventArgs*>* eventHandler, [out] [retval] EventRegistrationToken* eventCookie);
@@ -538,7 +538,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 
 	[contract(ClipboardContract, 4.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataTransferManager)]
-	[uuid(30AE7D71-8BA8-4C02-8E3F-DDB23B388715)]
+	[uuid(11c45fc0-76d6-4ff2-86f5-91481511b26c)]
 	interface IDataTransferManager2 : IInspectable
 	{
 		[eventadd] HRESULT ShareProvidersRequested([in] Windows.Foundation.TypedEventHandler<Microsoft.ProjectReunion.ApplicationModel.DataTransferManager*, Microsoft.ProjectReunion.ApplicationModel.ShareProvidersRequestedEventArgs*>* handler, [out] [retval] EventRegistrationToken* token);
@@ -547,7 +547,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 
 	[contract(ClipboardContract, 1.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataTransferManager)]
-	[uuid(A9DA01AA-E00E-4CFE-AA44-2DD932DCA3D8)]
+	[uuid(0dc0af01-b3ae-484c-9752-910ce975392f)]
 	interface IDataTransferManagerStatics : IInspectable
 	{
 		HRESULT ShowShareUI();
@@ -556,7 +556,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 
 	[contract(ClipboardContract, 3.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataTransferManager)]
-	[uuid(C54EC2EC-9F97-4D63-9868-395E271AD8F5)]
+	[uuid(0e9a748d-3b26-4b7b-9399-ee372d58bf32)]
 	interface IDataTransferManagerStatics2 : IInspectable
 	{
 		HRESULT IsSupported([out] [retval] boolean* value);
@@ -564,7 +564,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 
 	[contract(ClipboardContract, 5.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataTransferManager)]
-	[uuid(05845473-6C82-4F5C-AC23-62E458361FAC)]
+	[uuid(dfd9220a-e51c-4dad-8b41-86d15192faab)]
 	interface IDataTransferManagerStatics3 : IInspectable
 	{
 		[overload("ShowShareUI")] HRESULT ShowShareUIWithOptions([in] Microsoft.ProjectReunion.ApplicationModel.ShareUIOptions* options);
@@ -572,7 +572,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 
 	[contract(ClipboardContract, 1.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.HtmlFormatHelper)]
-	[uuid(E22E7749-DD70-446F-AEFC-61CEE59F655E)]
+	[uuid(cce26a46-4048-4fb4-99c8-b822d03cd526)]
 	interface IHtmlFormatHelperStatics : IInspectable
 	{
 		HRESULT GetStaticFragment([in] HSTRING htmlFormat, [out] [retval] HSTRING* htmlFragment);
@@ -581,7 +581,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 
 	[contract(ClipboardContract, 1.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.OperationCompletedEventArgs)]
-	[uuid(E7AF329D-051D-4FAB-B1A9-47FD77F70A41)]
+	[uuid(a180ab74-fcc7-42f3-a6bd-5d373a28fc8d)]
 	interface IOperationCompletedEventArgs : IInspectable
 	{
 		[propget] HRESULT Operation([out] [retval] Microsoft.ProjectReunion.ApplicationModel.DataPackageOperation* value);
@@ -589,7 +589,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 
 	[contract(ClipboardContract, 2.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.OperationCompletedEventArgs)]
-	[uuid(858FA073-1E19-4105-B2F7-C8478808D562)]
+	[uuid(42d44094-eebc-4e52-b98b-7d0bb646a96f)]
 	interface IOperationCompletedEventArgs2 : IInspectable
 	{
 		[propget] HRESULT AcceptedFormatId([out] [retval] HSTRING* value);
@@ -597,7 +597,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 
 	[contract(ClipboardContract, 4.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.ShareCompletedEventArgs)]
-	[uuid(4574C442-F913-4F60-9DF7-CC4060AB1916)]
+	[uuid(5107a2a6-6dd3-491a-8f1a-93a1867afa56)]
 	interface IShareCompletedEventArgs : IInspectable
 	{
 		[propget] HRESULT ShareTarget([out] [retval] Microsoft.ProjectReunion.ApplicationModel.ShareTargetInfo** value);
@@ -605,7 +605,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 
 	[contract(ClipboardContract, 4.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.ShareProvider)]
-	[uuid(2FABE026-443E-4CDA-AF25-8D81070EFD80)]
+	[uuid(6dcdc9a9-7118-43c5-ab39-c5b81ae919b3)]
 	interface IShareProvider : IInspectable
 	{
 		[propget] HRESULT Title([out] [retval] HSTRING* value);
@@ -617,7 +617,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 
 	[contract(ClipboardContract, 4.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.ShareProvider)]
-	[uuid(172A174C-E79E-4F6D-B07D-128F469E0296)]
+	[uuid(05994b01-3050-46ea-a2f1-db35deb79ab5)]
 	interface IShareProviderFactory : IInspectable
 	{
 		HRESULT Create([in] HSTRING title, [in] Windows.Storage.Streams.RandomAccessStreamReference* displayIcon, [in] Windows.UI.Color backgroundColor, [in] Microsoft.ProjectReunion.ApplicationModel.ShareProviderHandler* handler, [out] [retval] Microsoft.ProjectReunion.ApplicationModel.ShareProvider** result);
@@ -625,7 +625,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 
 	[contract(ClipboardContract, 4.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.ShareProviderOperation)]
-	[uuid(19CEF937-D435-4179-B6AF-14E0492B69F6)]
+	[uuid(6956d6f1-ab46-4bcf-a1d3-be8e9a7d31e7)]
 	interface IShareProviderOperation : IInspectable
 	{
 		[propget] HRESULT Data([out] [retval] Microsoft.ProjectReunion.ApplicationModel.DataPackageView** value);
@@ -635,7 +635,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 
 	[contract(ClipboardContract, 4.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.ShareProvidersRequestedEventArgs)]
-	[uuid(F888F356-A3F8-4FCE-85E4-8826E63BE799)]
+	[uuid(7314a2ef-4a97-4e53-b347-2316b67e9121)]
 	interface IShareProvidersRequestedEventArgs : IInspectable
 	{
 		[propget] HRESULT Providers([out] [retval] Windows.Foundation.Collections.IVector<Microsoft.ProjectReunion.ApplicationModel.ShareProvider*>** value);
@@ -645,7 +645,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 
 	[contract(ClipboardContract, 4.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.ShareTargetInfo)]
-	[uuid(385BE607-C6E8-4114-B294-28F3BB6F9904)]
+	[uuid(9b7ceae7-5d6f-4d29-9a17-427208267b9d)]
 	interface IShareTargetInfo : IInspectable
 	{
 		[propget] HRESULT AppUserModelId([out] [retval] HSTRING* value);
@@ -654,7 +654,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 
 	[contract(ClipboardContract, 5.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.ShareUIOptions)]
-	[uuid(72FA8A80-342F-4D90-9551-2AE04E37680C)]
+	[uuid(443a3262-9729-40e4-819c-015f62b4d1c5)]
 	interface IShareUIOptions : IInspectable
 	{
 		[propget] HRESULT Theme([out] [retval] Microsoft.ProjectReunion.ApplicationModel.ShareUITheme* value);
@@ -665,7 +665,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 
 	[contract(ClipboardContract, 1.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.SharedStorageAccessManager)]
-	[uuid(C6132ADA-34B1-4849-BD5F-D09FEE3158C5)]
+	[uuid(9b5b520e-1b1a-487a-be92-f214f21c255f)]
 	interface ISharedStorageAccessManagerStatics : IInspectable
 	{
 		HRESULT AddFile([in] Windows.Storage.IStorageFile* file, [out] [retval] HSTRING* outToken);
@@ -675,7 +675,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 
 	[contract(ClipboardContract, 1.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.StandardDataFormats)]
-	[uuid(7ED681A1-A880-40C9-B4ED-0BEE1E15F549)]
+	[uuid(18f4cbf8-64f1-4ba1-9e64-53648a0443a8)]
 	interface IStandardDataFormatsStatics : IInspectable
 	{
 		[propget] HRESULT Text([out] [retval] HSTRING* value);
@@ -688,7 +688,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 
 	[contract(ClipboardContract, 1.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.StandardDataFormats)]
-	[uuid(42A254F4-9D76-42E8-861B-47C25DD0CF71)]
+	[uuid(49fe04c9-d5f6-4416-a0cf-68a484e218b3)]
 	interface IStandardDataFormatsStatics2 : IInspectable
 	{
 		[propget] HRESULT WebLink([out] [retval] HSTRING* value);
@@ -697,7 +697,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 
 	[contract(ClipboardContract, 6.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.StandardDataFormats)]
-	[uuid(3B57B069-01D4-474C-8B5F-BC8E27F38B21)]
+	[uuid(8540c4ae-3d15-44ad-9a13-59fe48f111ba)]
 	interface IStandardDataFormatsStatics3 : IInspectable
 	{
 		[propget] HRESULT UserActivityJsonArray([out] [retval] HSTRING* value);
@@ -705,7 +705,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 
 	[contract(ClipboardContract, 1.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.TargetApplicationChosenEventArgs)]
-	[uuid(CA6FB8AC-2987-4EE3-9C54-D8AFBCB86C1D)]
+	[uuid(cdaa58b4-c944-4c6b-a8f4-f429131cc2ee)]
 	interface ITargetApplicationChosenEventArgs : IInspectable
 	{
 		[propget] HRESULT ApplicationName([out] [retval] HSTRING* value);

--- a/specs/clipboard-api/clipboard.idl
+++ b/specs/clipboard-api/clipboard.idl
@@ -54,8 +54,6 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 	interface IClipboardHistoryChangedEventArgs;
 	interface IClipboardHistoryItem;
 	interface IClipboardHistoryItemsResult;
-	interface IClipboardStatics;
-	interface IClipboardStatics2;
 	interface IDataPackage;
 	interface IDataPackage2;
 	interface IDataPackage3;
@@ -238,39 +236,6 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 	{
 		[propget] HRESULT Status([out] [retval] Microsoft.ProjectReunion.ApplicationModel.ClipboardHistoryItemsResultStatus* value);
 		[propget] HRESULT Items([out] [retval] Windows.Foundation.Collections.IVectorView<Microsoft.ProjectReunion.ApplicationModel.ClipboardHistoryItem*>** value);
-	}
-
-	[contract(ClipboardContract, 1.0)]
-	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.Clipboard)]
-	[uuid(6cb53030-4da0-43a1-95ab-52f87cf59c3a)]
-	interface IClipboardStatics : IInspectable
-	{
-		HRESULT GetContent([out] [retval] Microsoft.ProjectReunion.ApplicationModel.DataPackageView** result);
-		HRESULT SetContent([in] Microsoft.ProjectReunion.ApplicationModel.DataPackage* content);
-		HRESULT Flush();
-		HRESULT Clear();
-		[eventadd] HRESULT ContentChanged([in] Windows.Foundation.EventHandler<IInspectable*>* handler, [out] [retval] EventRegistrationToken* token);
-		[eventremove] HRESULT ContentChanged([in] EventRegistrationToken token);
-	}
-
-	[contract(ClipboardContract, 7.0)]
-	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.Clipboard)]
-	[uuid(d6baf461-6fc5-4e51-a4b1-fb07b3a7a9e0)]
-	interface IClipboardStatics2 : IInspectable
-	{
-		HRESULT GetHistoryItemsAsync([out] [retval] Windows.Foundation.IAsyncOperation<Microsoft.ProjectReunion.ApplicationModel.ClipboardHistoryItemsResult*>** operation);
-		HRESULT ClearHistory([out] [retval] boolean* result);
-		HRESULT DeleteItemFromHistory([in] Microsoft.ProjectReunion.ApplicationModel.ClipboardHistoryItem* item, [out] [retval] boolean* result);
-		HRESULT SetHistoryItemAsContent([in] Microsoft.ProjectReunion.ApplicationModel.ClipboardHistoryItem* item, [out] [retval] Microsoft.ProjectReunion.ApplicationModel.SetHistoryItemAsContentStatus* result);
-		HRESULT IsHistoryEnabled([out] [retval] boolean* result);
-		HRESULT IsRoamingEnabled([out] [retval] boolean* result);
-		HRESULT SetContentWithOptions([in] Microsoft.ProjectReunion.ApplicationModel.DataPackage* content, [in] Microsoft.ProjectReunion.ApplicationModel.ClipboardContentOptions* options, [out] [retval] boolean* result);
-		[eventadd] HRESULT HistoryChanged([in] Windows.Foundation.EventHandler<Microsoft.ProjectReunion.ApplicationModel.ClipboardHistoryChangedEventArgs*>* handler, [out] [retval] EventRegistrationToken* token);
-		[eventremove] HRESULT HistoryChanged([in] EventRegistrationToken token);
-		[eventadd] HRESULT RoamingEnabledChanged([in] Windows.Foundation.EventHandler<IInspectable*>* handler, [out] [retval] EventRegistrationToken* token);
-		[eventremove] HRESULT RoamingEnabledChanged([in] EventRegistrationToken token);
-		[eventadd] HRESULT HistoryEnabledChanged([in] Windows.Foundation.EventHandler<IInspectable*>* handler, [out] [retval] EventRegistrationToken* token);
-		[eventremove] HRESULT HistoryEnabledChanged([in] EventRegistrationToken token);
 	}
 
 	[contract(ClipboardContract, 1.0)]
@@ -711,13 +676,27 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 		[propget] HRESULT ApplicationName([out] [retval] HSTRING* value);
 	}
 
-	[contract(ClipboardContract, 1.0)]
+	[contract(ClipboardContract, 7.0)]
+	[static_name("Microsoft.ProjectReunion.ApplicationModel.IClipboardStatics", 6cb53030-4da0-43a1-95ab-52f87cf59c3a)]
 	[marshaling_behavior(standard)]
-	[static(Microsoft.ProjectReunion.ApplicationModel.IClipboardStatics, ClipboardContract, 1.0)]
-	[static(Microsoft.ProjectReunion.ApplicationModel.IClipboardStatics2, ClipboardContract, 7.0)]
-	[threading(both)]
 	runtimeclass Clipboard
 	{
+		static DataPackageView GetContent();
+		static void SetContent(DataPackage content);
+		static void Flush();
+		static void Clear();
+		static event Windows.Foundation.EventHandler<Object> ContentChanged;
+
+		static Windows.Foundation.IAsyncOperation<ClipboardHistoryItemsResult> GetHistoryItemsAsync();
+		static Boolean ClearHistory();
+		static Boolean DeleteItemFromHistory(ClipboardHistoryItem item);
+		static SetHistoryItemAsContentStatus SetHistoryItemAsContent(ClipboardHistoryItem item);
+		static Boolean IsHistoryEnabled();
+		static Boolean IsRoamingEnabled();
+		static Boolean SetContentWithOptions(DataPackage content, ClipboardContentOptions options);
+		static event Windows.Foundation.EventHandler<ClipboardHistoryChangedEventArgs> HistoryChanged;
+		static event Windows.Foundation.EventHandler<Object> RoamingEnabledChanged;
+		static event Windows.Foundation.EventHandler<Object> HistoryEnabledChanged;
 	}
 
 	[activatable(ClipboardContract, 7.0)]

--- a/specs/clipboard-api/clipboard.idl
+++ b/specs/clipboard-api/clipboard.idl
@@ -62,15 +62,6 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 	typedef enum ShareUITheme ShareUITheme;
 	delegate DataProviderHandler;
 	delegate ShareProviderHandler;
-	interface IDataPackagePropertySet;
-	interface IDataPackagePropertySet2;
-	interface IDataPackagePropertySet3;
-	interface IDataPackagePropertySet4;
-	interface IDataPackagePropertySetView;
-	interface IDataPackagePropertySetView2;
-	interface IDataPackagePropertySetView3;
-	interface IDataPackagePropertySetView4;
-	interface IDataPackagePropertySetView5;
 	interface IDataProviderDeferral;
 	interface IDataProviderRequest;
 	interface IDataRequest;
@@ -191,111 +182,6 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 	[uuid(0d89ad1d-bb56-43e0-89d3-df5f85af2dd6)]
 	delegate
 		HRESULT ShareProviderHandler([in] Microsoft.ProjectReunion.ApplicationModel.ShareProviderOperation* operation);
-
-	[contract(ClipboardContract, 1.0)]
-	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataPackagePropertySet)]
-	[uuid(6c1bd5dd-d89e-4f79-ae3b-4ad565586202)]
-	interface IDataPackagePropertySet : IInspectable
-		requires
-			Windows.Foundation.Collections.IMap<HSTRING, IInspectable*>,
-			Windows.Foundation.Collections.IIterable<Windows.Foundation.Collections.IKeyValuePair<HSTRING, IInspectable*>*>
-	{
-		[propget] HRESULT Title([out] [retval] HSTRING* value);
-		[propput] HRESULT Title([in] HSTRING value);
-		[propget] HRESULT Description([out] [retval] HSTRING* value);
-		[propput] HRESULT Description([in] HSTRING value);
-		[propget] HRESULT Thumbnail([out] [retval] Windows.Storage.Streams.IRandomAccessStreamReference** value);
-		[propput] HRESULT Thumbnail([in] Windows.Storage.Streams.IRandomAccessStreamReference* value);
-		[propget] HRESULT FileTypes([out] [retval] Windows.Foundation.Collections.IVector<HSTRING>** value);
-		[propget] HRESULT ApplicationName([out] [retval] HSTRING* value);
-		[propput] HRESULT ApplicationName([in] HSTRING value);
-		[propget] HRESULT ApplicationListingUri([out] [retval] Windows.Foundation.Uri** value);
-		[propput] HRESULT ApplicationListingUri([in] Windows.Foundation.Uri* value);
-	}
-
-	[contract(ClipboardContract, 1.0)]
-	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataPackagePropertySet)]
-	[uuid(744e9c77-6463-4b99-b3c3-f69d9ee594bf)]
-	interface IDataPackagePropertySet2 : IInspectable
-	{
-		[propget] HRESULT ContentSourceWebLink([out] [retval] Windows.Foundation.Uri** value);
-		[propput] HRESULT ContentSourceWebLink([in] Windows.Foundation.Uri* value);
-		[propget] HRESULT ContentSourceApplicationLink([out] [retval] Windows.Foundation.Uri** value);
-		[propput] HRESULT ContentSourceApplicationLink([in] Windows.Foundation.Uri* value);
-		[propget] HRESULT PackageFamilyName([out] [retval] HSTRING* value);
-		[propput] HRESULT PackageFamilyName([in] HSTRING value);
-		[propget] HRESULT Square30x30Logo([out] [retval] Windows.Storage.Streams.IRandomAccessStreamReference** value);
-		[propput] HRESULT Square30x30Logo([in] Windows.Storage.Streams.IRandomAccessStreamReference* value);
-		[propget] HRESULT LogoBackgroundColor([out] [retval] Windows.UI.Color* value);
-		[propput] HRESULT LogoBackgroundColor([in] Windows.UI.Color value);
-	}
-
-	[contract(ClipboardContract, 1.0)]
-	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataPackagePropertySet)]
-	[uuid(c8c24a60-f4b3-4ab0-88e9-c23062e0cc33)]
-	interface IDataPackagePropertySet3 : IInspectable
-	{
-		[propget] HRESULT EnterpriseId([out] [retval] HSTRING* value);
-		[propput] HRESULT EnterpriseId([in] HSTRING value);
-	}
-
-	[contract(ClipboardContract, 6.0)]
-	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataPackagePropertySet)]
-	[uuid(d1270af6-a2e8-4d31-b697-b48103d5a15a)]
-	interface IDataPackagePropertySet4 : IInspectable
-	{
-		[propget] HRESULT ContentSourceUserActivityJson([out] [retval] HSTRING* value);
-		[propput] HRESULT ContentSourceUserActivityJson([in] HSTRING value);
-	}
-
-	[contract(ClipboardContract, 1.0)]
-	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataPackagePropertySetView)]
-	[uuid(054c0bc4-ca76-4e7d-9511-4322a5a0b58b)]
-	interface IDataPackagePropertySetView : IInspectable
-	{
-		[propget] HRESULT Title([out] [retval] HSTRING* value);
-		[propget] HRESULT Description([out] [retval] HSTRING* value);
-		[propget] HRESULT Thumbnail([out] [retval] Windows.Storage.Streams.RandomAccessStreamReference** value);
-		[propget] HRESULT FileTypes([out] [retval] Windows.Foundation.Collections.IVectorView<HSTRING>** value);
-		[propget] HRESULT ApplicationName([out] [retval] HSTRING* value);
-		[propget] HRESULT ApplicationListingUri([out] [retval] Windows.Foundation.Uri** value);
-	}
-
-	[contract(ClipboardContract, 1.0)]
-	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataPackagePropertySetView)]
-	[uuid(e35b2f0d-1c7a-4bf3-ab72-50554054d7b2)]
-	interface IDataPackagePropertySetView2 : IInspectable
-	{
-		[propget] HRESULT PackageFamilyName([out] [retval] HSTRING* value);
-		[propget] HRESULT ContentSourceWebLink([out] [retval] Windows.Foundation.Uri** value);
-		[propget] HRESULT ContentSourceApplicationLink([out] [retval] Windows.Foundation.Uri** value);
-		[propget] HRESULT Square30x30Logo([out] [retval] Windows.Storage.Streams.IRandomAccessStreamReference** value);
-		[propget] HRESULT LogoBackgroundColor([out] [retval] Windows.UI.Color* value);
-	}
-
-	[contract(ClipboardContract, 1.0)]
-	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataPackagePropertySetView)]
-	[uuid(52067bc5-0b4c-4559-8da1-cc75dc6f2344)]
-	interface IDataPackagePropertySetView3 : IInspectable
-	{
-		[propget] HRESULT EnterpriseId([out] [retval] HSTRING* value);
-	}
-
-	[contract(ClipboardContract, 6.0)]
-	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataPackagePropertySetView)]
-	[uuid(0e1a2836-c904-4e63-be50-d3f743864782)]
-	interface IDataPackagePropertySetView4 : IInspectable
-	{
-		[propget] HRESULT ContentSourceUserActivityJson([out] [retval] HSTRING* value);
-	}
-
-	[contract(ClipboardContract, 7.0)]
-	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataPackagePropertySetView)]
-	[uuid(75ff681c-4bd4-4cfb-aede-9c3a7e6f245d)]
-	interface IDataPackagePropertySetView5 : IInspectable
-	{
-		[propget] HRESULT IsFromRoamingClipboard([out] [retval] boolean* value);
-	}
 
 	[contract(ClipboardContract, 1.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataProviderDeferral)]
@@ -563,29 +449,55 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 		event Windows.Foundation.TypedEventHandler<DataPackage, Object> ShareCanceled;
 	}
 
-	[contract(ClipboardContract, 1.0)]
-	[marshaling_behavior(agile)]
-	runtimeclass DataPackagePropertySet
+	[contract(ClipboardContract, 6.0)]
+	[interface_name("Microsoft.ProjectReunion.ApplicationModel.IDataPackagePropertySet", 6c1bd5dd-d89e-4f79-ae3b-4ad565586202)]
+	runtimeclass DataPackagePropertySet :
+		Windows.Foundation.Collections.IMap<String, Object>
+		, Windows.Foundation.Collections.IIterable<Windows.Foundation.Collections.IKeyValuePair<String, Object> >
 	{
-		[default] interface Microsoft.ProjectReunion.ApplicationModel.IDataPackagePropertySet;
-		interface Windows.Foundation.Collections.IMap<HSTRING, IInspectable*>;
-		interface Windows.Foundation.Collections.IIterable<Windows.Foundation.Collections.IKeyValuePair<HSTRING, IInspectable*>*>;
-		[contract(ClipboardContract, 1.0)] interface Microsoft.ProjectReunion.ApplicationModel.IDataPackagePropertySet2;
-		[contract(ClipboardContract, 1.0)] interface Microsoft.ProjectReunion.ApplicationModel.IDataPackagePropertySet3;
-		[contract(ClipboardContract, 6.0)] interface Microsoft.ProjectReunion.ApplicationModel.IDataPackagePropertySet4;
+		String Title;
+		String Description;
+		Windows.Storage.Streams.IRandomAccessStreamReference Thumbnail;
+		Windows.Foundation.Collections.IVector<String> FileTypes { get; };
+		String ApplicationName;
+		Windows.Foundation.Uri ApplicationListingUri;
+
+		Windows.Foundation.Uri ContentSourceWebLink;
+		Windows.Foundation.Uri ContentSourceApplicationLink;
+		String PackageFamilyName;
+		Windows.Storage.Streams.IRandomAccessStreamReference Square30x30Logo;
+		Windows.UI.Color LogoBackgroundColor;
+
+		String EnterpriseId;
+
+		String ContentSourceUserActivityJson;
 	}
 
-	[contract(ClipboardContract, 1.0)]
-	[marshaling_behavior(agile)]
-	runtimeclass DataPackagePropertySetView
+	[contract(ClipboardContract, 7.0)]
+	[interface_name("Microsoft.ProjectReunion.ApplicationModel.IDataPackagePropertySetView", 054c0bc4-ca76-4e7d-9511-4322a5a0b58b)]
+	[hasvariant]
+	runtimeclass DataPackagePropertySetView :
+		Windows.Foundation.Collections.IMapView<String, Object>
+		, Windows.Foundation.Collections.IIterable<Windows.Foundation.Collections.IKeyValuePair<String, Object> >
 	{
-		[default] interface Microsoft.ProjectReunion.ApplicationModel.IDataPackagePropertySetView;
-		[contract(ClipboardContract, 1.0)] interface Microsoft.ProjectReunion.ApplicationModel.IDataPackagePropertySetView2;
-		[contract(ClipboardContract, 1.0)] interface Microsoft.ProjectReunion.ApplicationModel.IDataPackagePropertySetView3;
-		[contract(ClipboardContract, 6.0)] interface Microsoft.ProjectReunion.ApplicationModel.IDataPackagePropertySetView4;
-		[contract(ClipboardContract, 7.0)] interface Microsoft.ProjectReunion.ApplicationModel.IDataPackagePropertySetView5;
-		interface Windows.Foundation.Collections.IMapView<HSTRING, IInspectable*>;
-		interface Windows.Foundation.Collections.IIterable<Windows.Foundation.Collections.IKeyValuePair<HSTRING, IInspectable*>*>;
+		String Title { get; };
+		String Description { get; };
+		Windows.Storage.Streams.IRandomAccessStreamReference Thumbnail { get; };
+		Windows.Foundation.Collections.IVector<String> FileTypes { get; };
+		String ApplicationName { get; };
+		Windows.Foundation.Uri ApplicationListingUri { get; };
+
+		String PackageFamilyName { get; };
+		Windows.Foundation.Uri ContentSourceWebLink { get; };
+		Windows.Foundation.Uri ContentSourceApplicationLink { get; };
+		Windows.Storage.Streams.IRandomAccessStreamReference Square30x30Logo { get; };
+		Windows.UI.Color LogoBackgroundColor { get; };
+
+		String EnterpriseId { get; };
+
+		String ContentSourceUserActivityJson { get; };
+
+		Boolean IsFromRoamingClipboard { get; };
 	}
 
 	[contract(ClipboardContract, 2.0)]

--- a/specs/clipboard-api/clipboard.idl
+++ b/specs/clipboard-api/clipboard.idl
@@ -11,7 +11,7 @@ import "Windows.Storage.Streams.idl";
 import "Windows.UI.idl";
 #include <sdkddkver.h>
 
-// Forward Declare
+// Forward declarations
 namespace Windows.Foundation
 {
   typedef struct DateTime DateTime;
@@ -60,13 +60,9 @@ namespace Microsoft.ProjectReunion.ApplicationModel
   [contractversion(1.0)]
   apicontract ClipboardContract { };
 
-  typedef enum ClipboardHistoryItemsResultStatus ClipboardHistoryItemsResultStatus;
-  typedef enum DataPackageOperation DataPackageOperation;
-  typedef enum SetHistoryItemAsContentStatus SetHistoryItemAsContentStatus;
   delegate DataProviderHandler;
   runtimeclass Clipboard;
   runtimeclass ClipboardContentOptions;
-  runtimeclass ClipboardHistoryChangedEventArgs;
   runtimeclass ClipboardHistoryItem;
   runtimeclass ClipboardHistoryItemsResult;
   runtimeclass DataPackage;
@@ -88,7 +84,6 @@ namespace Microsoft.ProjectReunion.ApplicationModel
     interface Windows.Foundation.Collections.IIterable<ClipboardHistoryItem*>;
     interface Windows.Foundation.Collections.IIterator<ClipboardHistoryItem*>;
     interface Windows.Foundation.Collections.IVectorView<ClipboardHistoryItem*>;
-    interface Windows.Foundation.EventHandler<ClipboardHistoryChangedEventArgs*>;
     interface Windows.Foundation.IAsyncOperation<ClipboardHistoryItemsResult*>;
     interface Windows.Foundation.IAsyncOperation<DataPackage*>;
     interface Windows.Foundation.IAsyncOperation<DataPackageOperation>;
@@ -100,6 +95,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 // Type definitions
 namespace Microsoft.ProjectReunion.ApplicationModel
 {
+
   // FIXME: Figure out how to declare these enums without causing definition conflicts
   // between the enum constants and the same-named ones in
   // Windows.ApplicationModel.DataTransfer
@@ -136,16 +132,15 @@ namespace Microsoft.ProjectReunion.ApplicationModel
   /// data format in a <see cref="DataPackage"/>.
   /// </summary>
   [contract(ClipboardContract, 1.0)]
-  [uuid(6d9e7bfb-3280-4219-be29-08145f30f4e5)]
   delegate void DataProviderHandler(DataProviderRequest request);
 
   /// <summary>
-  /// Top-level API for reading, writing, and monitoring the system clipboard
-  /// and clipboard history, if available. Clipboard history also
-  /// includes clipboard items roamed from your other devices through the cloud.
+  /// Top-level API for reading, writing, and monitoring the system clipboard,
+  /// as well as clipboard history, if available on the current Windows version
+  /// and enabled by the user. Clipboard history also includes clipboard items
+  /// roamed from your other devices through the cloud.
   /// </summary>
   [contract(ClipboardContract, 1.0)]
-  [static_name("IClipboardStatics", 6cb53030-4da0-43a1-95ab-52f87cf59c3a)]
   [marshaling_behavior(standard)]
   static runtimeclass Clipboard
   {
@@ -166,16 +161,17 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 
     static Boolean SetContentWithOptions(DataPackage content, ClipboardContentOptions options);
 
-    static event Windows.Foundation.EventHandler<ClipboardHistoryChangedEventArgs> HistoryChanged;
+    static event Windows.Foundation.EventHandler<Object> HistoryChanged;
     static event Windows.Foundation.EventHandler<Object> RoamingEnabledChanged;
     static event Windows.Foundation.EventHandler<Object> HistoryEnabledChanged;
   }
 
   /// <summary>
-  /// Settings your app can set for a new item it cuts or copies onto the clipboard.
+  /// Clipboard history-related settings your app can set for a new item
+  /// that it cuts or copies onto the clipboard using
+  /// <see cref="Clipboard.SetContentWithOptions"/>.
   /// </summary>
   [contract(ClipboardContract, 1.0)]
-  [interface_name("IClipboardContentOptions", c31b927f-1008-4e98-b575-adf175ccdd0b)]
   runtimeclass ClipboardContentOptions
   {
     ClipboardContentOptions();
@@ -187,19 +183,9 @@ namespace Microsoft.ProjectReunion.ApplicationModel
   }
 
   /// <summary>
-  /// Input parameters for the <see cref="Clipboard.HistoryChanged"/> event.
-  /// </summary>
-  // TO CONSIDER: should this class be omitted since it was empty in-box?
-  [contract(ClipboardContract, 1.0)]
-  [interface_name("IClipboardHistoryChangedEventArgs", 9d1960c7-cf0a-4e51-943c-72373b7a2579)]
-  runtimeclass ClipboardHistoryChangedEventArgs
-  { }
-
-  /// <summary>
   /// An item retrieved from the clipboard history log.
   /// </summary>
   [contract(ClipboardContract, 1.0)]
-  [interface_name("IClipboardHistoryItem", 1907eff8-7d2f-4a71-8a56-bd02effeb184)]
   runtimeclass ClipboardHistoryItem
   {
     String Id { get; };
@@ -211,7 +197,6 @@ namespace Microsoft.ProjectReunion.ApplicationModel
   /// Return value for a call to <see cref="Clipboard.GetHistoryItemsAsync"/>.
   /// </summary>
   [contract(ClipboardContract, 1.0)]
-  [interface_name("IClipboardHistoryItemsResult", 2f6c9705-f56b-42f0-b1a1-fc2d46d572e7)]
   runtimeclass ClipboardHistoryItemsResult
   {
     ClipboardHistoryItemsResultStatus Status { get; };
@@ -222,11 +207,10 @@ namespace Microsoft.ProjectReunion.ApplicationModel
   /// Basic unit of data transfer for <see cref="Clipboard"/>.
   /// Allows data to be sent in multiple "formats". Certain formats can be
   /// "delay rendered", meaning they are not serialized immediately into
-  /// the DataPackage but instead a creator-provided callback will
+  /// the DataPackage, but instead a creator-provided callback will
   /// serialize them on demand.
   /// </summary>
   [contract(ClipboardContract, 1.0)]
-  [interface_name("IDataPackage", 36861532-b01e-49c5-9a0b-2282d079c9ac)]
   runtimeclass DataPackage
   {
     DataPackage();
@@ -260,7 +244,6 @@ namespace Microsoft.ProjectReunion.ApplicationModel
   /// Read-only view of a <see cref="DataPackage"/>.
   /// </summary>
   [contract(ClipboardContract, 1.0)]
-  [interface_name("IDataPackageView", 659f7a31-3335-4e57-b373-8898ffae5ab1)]
   runtimeclass DataPackageView
   {
     DataPackagePropertySetView Properties { get; };
@@ -310,7 +293,6 @@ namespace Microsoft.ProjectReunion.ApplicationModel
   { }
 
   [contract(ClipboardContract, 1.0)]
-  [uuid(6c1bd5dd-d89e-4f79-ae3b-4ad565586202)]
   [exclusiveto(DataPackagePropertySet)]
   [hasvariant]
   interface IDataPackagePropertySet requires
@@ -346,7 +328,6 @@ namespace Microsoft.ProjectReunion.ApplicationModel
   { }
 
   [contract(ClipboardContract, 1.0)]
-  [uuid(054c0bc4-ca76-4e7d-9511-4322a5a0b58b)]
   [exclusiveto(DataPackagePropertySetView)]
   [hasvariant]
   interface IDataPackagePropertySetView requires
@@ -378,7 +359,6 @@ namespace Microsoft.ProjectReunion.ApplicationModel
   /// a delay rendering, with the ability to signal the system when done.
   /// </summary>
   [contract(ClipboardContract, 1.0)]
-  [interface_name("IDataProviderDeferral", 4f9a822c-1bb1-4c3e-b908-e202c8b87f4c)]
   runtimeclass DataProviderDeferral
   {
     void Complete();
@@ -388,7 +368,6 @@ namespace Microsoft.ProjectReunion.ApplicationModel
   /// Input to a <see cref="DataProviderHandler"/> function for delay-rendering.
   /// </summary>
   [contract(ClipboardContract, 1.0)]
-  [interface_name("IDataProviderRequest", 25f2c71c-832b-4b8e-b9e9-672f098d2770)]
   runtimeclass DataProviderRequest
   {
     String FormatId { get; };
@@ -402,7 +381,6 @@ namespace Microsoft.ProjectReunion.ApplicationModel
   /// used by <see cref="StandardDataFormats.Html"/>, described here:
   /// https://docs.microsoft.com/windows/win32/dataxchg/html-clipboard-format
   /// </summary>
-  [static_name("IHtmlFormatHelperStatics", cce26a46-4048-4fb4-99c8-b822d03cd526)]
   static runtimeclass HtmlFormatHelper
   {
     static String GetStaticFragment(String htmlFormat);
@@ -413,9 +391,9 @@ namespace Microsoft.ProjectReunion.ApplicationModel
   /// Input parameters for <see cref="DataPackage.OperationCompleted"/> event handler functions.
   /// </summary>
   [contract(ClipboardContract, 1.0)]
-  [interface_name("IOperationCompletedEventArgs", a180ab74-fcc7-42f3-a6bd-5d373a28fc8d)]
   runtimeclass OperationCompletedEventArgs
-  // FIXME: since the namespace is now ApplicationModel, this name is too generic. Should rename?
+  // FIXME: since the namespace is now ApplicationModel, the name OperationCompletedEventArgs
+  // is too generic. Should we rename it?
   {
     DataPackageOperation Operation { get; };
 
@@ -427,7 +405,6 @@ namespace Microsoft.ProjectReunion.ApplicationModel
   /// to the <see cref="DataPackage"/> system.
   /// </summary>
   [contract(ClipboardContract, 1.0)]
-  [static_name("IStandardDataFormatsStatics", 18f4cbf8-64f1-4ba1-9e64-53648a0443a8)]
   static runtimeclass StandardDataFormats
   {
     static String Text { get; };
@@ -441,5 +418,4 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 
     static String UserActivityJsonArray { get; };
   }
-
 }

--- a/specs/clipboard-api/clipboard.idl
+++ b/specs/clipboard-api/clipboard.idl
@@ -14,375 +14,375 @@ import "Windows.UI.idl";
 // Forward Declare
 namespace Windows.Foundation
 {
-	typedef struct DateTime DateTime;
-	runtimeclass Uri;
+  typedef struct DateTime DateTime;
+  runtimeclass Uri;
 }
 
 namespace Windows.Foundation.Metadata
 {
 
-	// FIXME: Figure out how to actually forward declare/prototype this WinRT Foundation attribute
-	// without defining it
+  // FIXME: Figure out how to actually forward declare/prototype this WinRT Foundation attribute
+  // without defining it
 
-	[attributeusage(target_all)]
-	[attributename("hasvariant")]
-	[version(NTDDI_WIN8)]
-	attribute HasVariantAttribute
-	{
-	}
+  [attributeusage(target_all)]
+  [attributename("hasvariant")]
+  [version(NTDDI_WIN8)]
+  attribute HasVariantAttribute
+  {
+  }
 }
 
 namespace Windows.Security.EnterpriseData
 {
-	typedef enum ProtectionPolicyEvaluationResult ProtectionPolicyEvaluationResult;
+  typedef enum ProtectionPolicyEvaluationResult ProtectionPolicyEvaluationResult;
 }
 
 namespace Windows.Storage
 {
-	interface IStorageItem;
-	interface IStorageFile;
-	runtimeclass StorageFile;
+  interface IStorageItem;
+  interface IStorageFile;
+  runtimeclass StorageFile;
 }
 
 namespace Windows.Storage.Streams
 {
-	interface IRandomAccessStreamReference;
-	runtimeclass RandomAccessStreamReference;
+  interface IRandomAccessStreamReference;
+  runtimeclass RandomAccessStreamReference;
 }
 
 namespace Windows.UI
 {
-	typedef struct Color Color;
+  typedef struct Color Color;
 }
 
 namespace Microsoft.ProjectReunion.ApplicationModel
 {
-	[contractversion(1.0)]
-	apicontract ClipboardContract { };
+  [contractversion(1.0)]
+  apicontract ClipboardContract { };
 
-	typedef enum ClipboardHistoryItemsResultStatus ClipboardHistoryItemsResultStatus;
-	typedef enum DataPackageOperation DataPackageOperation;
-	typedef enum SetHistoryItemAsContentStatus SetHistoryItemAsContentStatus;
-	delegate DataProviderHandler;
-	runtimeclass Clipboard;
-	runtimeclass ClipboardContentOptions;
-	runtimeclass ClipboardHistoryChangedEventArgs;
-	runtimeclass ClipboardHistoryItem;
-	runtimeclass ClipboardHistoryItemsResult;
-	runtimeclass DataPackage;
-	runtimeclass DataPackagePropertySet;
-	runtimeclass DataPackagePropertySetView;
-	runtimeclass DataPackageView;
-	runtimeclass DataProviderDeferral;
-	runtimeclass DataProviderRequest;
-	runtimeclass HtmlFormatHelper;
-	runtimeclass OperationCompletedEventArgs;
-	runtimeclass StandardDataFormats;
+  typedef enum ClipboardHistoryItemsResultStatus ClipboardHistoryItemsResultStatus;
+  typedef enum DataPackageOperation DataPackageOperation;
+  typedef enum SetHistoryItemAsContentStatus SetHistoryItemAsContentStatus;
+  delegate DataProviderHandler;
+  runtimeclass Clipboard;
+  runtimeclass ClipboardContentOptions;
+  runtimeclass ClipboardHistoryChangedEventArgs;
+  runtimeclass ClipboardHistoryItem;
+  runtimeclass ClipboardHistoryItemsResult;
+  runtimeclass DataPackage;
+  runtimeclass DataPackagePropertySet;
+  runtimeclass DataPackagePropertySetView;
+  runtimeclass DataPackageView;
+  runtimeclass DataProviderDeferral;
+  runtimeclass DataProviderRequest;
+  runtimeclass HtmlFormatHelper;
+  runtimeclass OperationCompletedEventArgs;
+  runtimeclass StandardDataFormats;
 }
 
 // Generic instantiations
 namespace Microsoft.ProjectReunion.ApplicationModel
 {
-	declare
-	{
-		interface Windows.Foundation.Collections.IIterable<ClipboardHistoryItem*>;
-		interface Windows.Foundation.Collections.IIterator<ClipboardHistoryItem*>;
-		interface Windows.Foundation.Collections.IVectorView<ClipboardHistoryItem*>;
-		interface Windows.Foundation.EventHandler<ClipboardHistoryChangedEventArgs*>;
-		interface Windows.Foundation.IAsyncOperation<ClipboardHistoryItemsResult*>;
-		interface Windows.Foundation.IAsyncOperation<DataPackage*>;
-		interface Windows.Foundation.IAsyncOperation<DataPackageOperation>;
-		interface Windows.Foundation.TypedEventHandler<DataPackage*, IInspectable*>;
-		interface Windows.Foundation.TypedEventHandler<DataPackage*, OperationCompletedEventArgs*>;
-	}
+  declare
+  {
+    interface Windows.Foundation.Collections.IIterable<ClipboardHistoryItem*>;
+    interface Windows.Foundation.Collections.IIterator<ClipboardHistoryItem*>;
+    interface Windows.Foundation.Collections.IVectorView<ClipboardHistoryItem*>;
+    interface Windows.Foundation.EventHandler<ClipboardHistoryChangedEventArgs*>;
+    interface Windows.Foundation.IAsyncOperation<ClipboardHistoryItemsResult*>;
+    interface Windows.Foundation.IAsyncOperation<DataPackage*>;
+    interface Windows.Foundation.IAsyncOperation<DataPackageOperation>;
+    interface Windows.Foundation.TypedEventHandler<DataPackage*, IInspectable*>;
+    interface Windows.Foundation.TypedEventHandler<DataPackage*, OperationCompletedEventArgs*>;
+  }
 }
 
 // Type definitions
 namespace Microsoft.ProjectReunion.ApplicationModel
 {
-	// FIXME: Figure out how to declare these enums without causing definition conflicts
-	// between the enum constants and the same-named ones in
-	// Windows.ApplicationModel.DataTransfer
+  // FIXME: Figure out how to declare these enums without causing definition conflicts
+  // between the enum constants and the same-named ones in
+  // Windows.ApplicationModel.DataTransfer
 
-	[contract(ClipboardContract, 1.0)]
-	enum ClipboardHistoryItemsResultStatus
-	{
-		aaaSuccess                  = 0,
-		aaaAccessDenied             = 1,
-		aaaClipboardHistoryDisabled = 2,
-	};
+  [contract(ClipboardContract, 1.0)]
+  enum ClipboardHistoryItemsResultStatus
+  {
+    aaaSuccess                  = 0,
+    aaaAccessDenied             = 1,
+    aaaClipboardHistoryDisabled = 2,
+  };
 
-	[contract(ClipboardContract, 1.0)]
-	[flags]
-	enum DataPackageOperation
-	{
-		aaaNone = 0x0,
-		aaaCopy = 0x1,
-		aaaMove = 0x2,
-		aaaLink = 0x4,
-	};
+  [contract(ClipboardContract, 1.0)]
+  [flags]
+  enum DataPackageOperation
+  {
+    aaaNone = 0x0,
+    aaaCopy = 0x1,
+    aaaMove = 0x2,
+    aaaLink = 0x4,
+  };
 
-	[contract(ClipboardContract, 1.0)]
-	enum SetHistoryItemAsContentStatus
-	{
-		aaaSuccess      = 0,
-		aaaAccessDenied = 1,
-		aaaItemDeleted  = 2,
-	};
+  [contract(ClipboardContract, 1.0)]
+  enum SetHistoryItemAsContentStatus
+  {
+    aaaSuccess      = 0,
+    aaaAccessDenied = 1,
+    aaaItemDeleted  = 2,
+  };
 
-	[contract(ClipboardContract, 1.0)]
-	[uuid(6d9e7bfb-3280-4219-be29-08145f30f4e5)]
-	delegate void DataProviderHandler(DataProviderRequest request);
+  [contract(ClipboardContract, 1.0)]
+  [uuid(6d9e7bfb-3280-4219-be29-08145f30f4e5)]
+  delegate void DataProviderHandler(DataProviderRequest request);
 
-	[contract(ClipboardContract, 1.0)]
-	[static_name("Microsoft.ProjectReunion.ApplicationModel.IClipboardStatics", 6cb53030-4da0-43a1-95ab-52f87cf59c3a)]
-	[marshaling_behavior(standard)]
-	static runtimeclass Clipboard
-	{
-		static DataPackageView GetContent();
-		static void SetContent(DataPackage content);
+  [contract(ClipboardContract, 1.0)]
+  [static_name("Microsoft.ProjectReunion.ApplicationModel.IClipboardStatics", 6cb53030-4da0-43a1-95ab-52f87cf59c3a)]
+  [marshaling_behavior(standard)]
+  static runtimeclass Clipboard
+  {
+    static DataPackageView GetContent();
+    static void SetContent(DataPackage content);
 
-		static void Flush();
-		static void Clear();
+    static void Flush();
+    static void Clear();
 
-		static event Windows.Foundation.EventHandler<Object> ContentChanged;
+    static event Windows.Foundation.EventHandler<Object> ContentChanged;
 
-		static Windows.Foundation.IAsyncOperation<ClipboardHistoryItemsResult> GetHistoryItemsAsync();
-		static Boolean ClearHistory();
-		static Boolean DeleteItemFromHistory(ClipboardHistoryItem item);
-		static SetHistoryItemAsContentStatus SetHistoryItemAsContent(ClipboardHistoryItem item);
-		static Boolean IsHistoryEnabled();
-		static Boolean IsRoamingEnabled();
+    static Windows.Foundation.IAsyncOperation<ClipboardHistoryItemsResult> GetHistoryItemsAsync();
+    static Boolean ClearHistory();
+    static Boolean DeleteItemFromHistory(ClipboardHistoryItem item);
+    static SetHistoryItemAsContentStatus SetHistoryItemAsContent(ClipboardHistoryItem item);
+    static Boolean IsHistoryEnabled();
+    static Boolean IsRoamingEnabled();
 
-		static Boolean SetContentWithOptions(DataPackage content, ClipboardContentOptions options);
+    static Boolean SetContentWithOptions(DataPackage content, ClipboardContentOptions options);
 
-		static event Windows.Foundation.EventHandler<ClipboardHistoryChangedEventArgs> HistoryChanged;
-		static event Windows.Foundation.EventHandler<Object> RoamingEnabledChanged;
-		static event Windows.Foundation.EventHandler<Object> HistoryEnabledChanged;
-	}
+    static event Windows.Foundation.EventHandler<ClipboardHistoryChangedEventArgs> HistoryChanged;
+    static event Windows.Foundation.EventHandler<Object> RoamingEnabledChanged;
+    static event Windows.Foundation.EventHandler<Object> HistoryEnabledChanged;
+  }
 
-	[contract(ClipboardContract, 1.0)]
-	[interface_name("Microsoft.ProjectReunion.ApplicationModel.IClipboardContentOptions", c31b927f-1008-4e98-b575-adf175ccdd0b)]
-	runtimeclass ClipboardContentOptions
-	{
-		ClipboardContentOptions();
-	
-		Boolean IsRoamable;
-		Boolean IsAllowedInHistory;
-		Windows.Foundation.Collections.IVector<String> RoamingFormats { get; };
-		Windows.Foundation.Collections.IVector<String> HistoryFormats { get; };
-	}
+  [contract(ClipboardContract, 1.0)]
+  [interface_name("Microsoft.ProjectReunion.ApplicationModel.IClipboardContentOptions", c31b927f-1008-4e98-b575-adf175ccdd0b)]
+  runtimeclass ClipboardContentOptions
+  {
+    ClipboardContentOptions();
 
-	[contract(ClipboardContract, 1.0)]
-	[interface_name("Microsoft.ProjectReunion.ApplicationModel.IClipboardHistoryChangedEventArgs", 9d1960c7-cf0a-4e51-943c-72373b7a2579)]
-	runtimeclass ClipboardHistoryChangedEventArgs
-	{ }
+    Boolean IsRoamable;
+    Boolean IsAllowedInHistory;
+    Windows.Foundation.Collections.IVector<String> RoamingFormats { get; };
+    Windows.Foundation.Collections.IVector<String> HistoryFormats { get; };
+  }
 
-	[contract(ClipboardContract, 1.0)]
-	[interface_name("Microsoft.ProjectReunion.ApplicationModel.IClipboardHistoryItem", 1907eff8-7d2f-4a71-8a56-bd02effeb184)]
-	runtimeclass ClipboardHistoryItem
-	{
-		String Id { get; };
-		Windows.Foundation.DateTime Timestamp { get; };
-		DataPackageView Content { get; };
-	}
+  [contract(ClipboardContract, 1.0)]
+  [interface_name("Microsoft.ProjectReunion.ApplicationModel.IClipboardHistoryChangedEventArgs", 9d1960c7-cf0a-4e51-943c-72373b7a2579)]
+  runtimeclass ClipboardHistoryChangedEventArgs
+  { }
 
-	[contract(ClipboardContract, 1.0)]
-	[interface_name("Microsoft.ProjectReunion.ApplicationModel.IClipboardHistoryItemsResult", 2f6c9705-f56b-42f0-b1a1-fc2d46d572e7)]
-	runtimeclass ClipboardHistoryItemsResult
-	{
-		ClipboardHistoryItemsResultStatus Status { get; };
-		Windows.Foundation.Collections.IVectorView<ClipboardHistoryItem> Items { get; };
-	}
+  [contract(ClipboardContract, 1.0)]
+  [interface_name("Microsoft.ProjectReunion.ApplicationModel.IClipboardHistoryItem", 1907eff8-7d2f-4a71-8a56-bd02effeb184)]
+  runtimeclass ClipboardHistoryItem
+  {
+    String Id { get; };
+    Windows.Foundation.DateTime Timestamp { get; };
+    DataPackageView Content { get; };
+  }
 
-	[contract(ClipboardContract, 1.0)]
-	[interface_name("Microsoft.ProjectReunion.ApplicationModel.IDataPackage", 36861532-b01e-49c5-9a0b-2282d079c9ac)]
-	runtimeclass DataPackage
-	{
-		DataPackage();
+  [contract(ClipboardContract, 1.0)]
+  [interface_name("Microsoft.ProjectReunion.ApplicationModel.IClipboardHistoryItemsResult", 2f6c9705-f56b-42f0-b1a1-fc2d46d572e7)]
+  runtimeclass ClipboardHistoryItemsResult
+  {
+    ClipboardHistoryItemsResultStatus Status { get; };
+    Windows.Foundation.Collections.IVectorView<ClipboardHistoryItem> Items { get; };
+  }
 
-		DataPackageView GetView();
-		DataPackagePropertySet Properties { get; };
-		DataPackageOperation RequestedOperation;
-		event Windows.Foundation.TypedEventHandler<DataPackage, OperationCompletedEventArgs> OperationCompleted;
-		event Windows.Foundation.TypedEventHandler<DataPackage, Object> Destroyed;
-		void SetData(String formatId, [hasvariant] Object value);
-		void SetDataProvider(String formatId, DataProviderHandler delayRenderer);
-		void SetText(String value);
-		[deprecated("SetUri may be altered or unavailable in future releases. Instead, use SetWebLink or SetApplicationLink.", deprecate, ClipboardContract, 1.0)]
-		void SetUri(Windows.Foundation.Uri value);
-		void SetHtmlFormat(String value);
+  [contract(ClipboardContract, 1.0)]
+  [interface_name("Microsoft.ProjectReunion.ApplicationModel.IDataPackage", 36861532-b01e-49c5-9a0b-2282d079c9ac)]
+  runtimeclass DataPackage
+  {
+    DataPackage();
 
-		Windows.Foundation.Collections.IMap<String, Windows.Storage.Streams.RandomAccessStreamReference> ResourceMap { get; };
+    DataPackageView GetView();
+    DataPackagePropertySet Properties { get; };
+    DataPackageOperation RequestedOperation;
+    event Windows.Foundation.TypedEventHandler<DataPackage, OperationCompletedEventArgs> OperationCompleted;
+    event Windows.Foundation.TypedEventHandler<DataPackage, Object> Destroyed;
+    void SetData(String formatId, [hasvariant] Object value);
+    void SetDataProvider(String formatId, DataProviderHandler delayRenderer);
+    void SetText(String value);
+    [deprecated("SetUri may be altered or unavailable in future releases. Instead, use SetWebLink or SetApplicationLink.", deprecate, ClipboardContract, 1.0)]
+    void SetUri(Windows.Foundation.Uri value);
+    void SetHtmlFormat(String value);
 
-		void SetRtf(String value);
-		void SetBitmap(Windows.Storage.Streams.RandomAccessStreamReference value);
+    Windows.Foundation.Collections.IMap<String, Windows.Storage.Streams.RandomAccessStreamReference> ResourceMap { get; };
 
-		[method_name("SetStorageItemsReadOnly")]
-		void SetStorageItems(Windows.Foundation.Collections.IIterable<Windows.Storage.IStorageItem> value);
-		[method_name("SetStorageItems")]
-		void SetStorageItems(Windows.Foundation.Collections.IIterable<Windows.Storage.IStorageItem> value, Boolean readOnly);
+    void SetRtf(String value);
+    void SetBitmap(Windows.Storage.Streams.RandomAccessStreamReference value);
 
-		void SetApplicationLink(Windows.Foundation.Uri value);
-		void SetWebLink(Windows.Foundation.Uri value);
-	}
+    [method_name("SetStorageItemsReadOnly")]
+    void SetStorageItems(Windows.Foundation.Collections.IIterable<Windows.Storage.IStorageItem> value);
+    [method_name("SetStorageItems")]
+    void SetStorageItems(Windows.Foundation.Collections.IIterable<Windows.Storage.IStorageItem> value, Boolean readOnly);
 
-	[contract(ClipboardContract, 1.0)]
-	runtimeclass DataPackagePropertySet :
-		[default] IDataPackagePropertySet
-		, Windows.Foundation.Collections.IMap<String, Object>
-		, Windows.Foundation.Collections.IIterable<Windows.Foundation.Collections.IKeyValuePair<String, Object> >
-	{ }
+    void SetApplicationLink(Windows.Foundation.Uri value);
+    void SetWebLink(Windows.Foundation.Uri value);
+  }
 
-	[contract(ClipboardContract, 1.0)]
-	[uuid(6c1bd5dd-d89e-4f79-ae3b-4ad565586202)]
-	[exclusiveto(DataPackagePropertySet)]
-	[hasvariant]
-	interface IDataPackagePropertySet requires
-		Windows.Foundation.Collections.IMap<String, Object>
-		, Windows.Foundation.Collections.IIterable<Windows.Foundation.Collections.IKeyValuePair<String, Object> >
-	{
-		String Title;
-		String Description;
-		Windows.Storage.Streams.IRandomAccessStreamReference Thumbnail;
-		Windows.Foundation.Collections.IVector<String> FileTypes { get; };
-		String ApplicationName;
-		Windows.Foundation.Uri ApplicationListingUri;
+  [contract(ClipboardContract, 1.0)]
+  runtimeclass DataPackagePropertySet :
+    [default] IDataPackagePropertySet
+    , Windows.Foundation.Collections.IMap<String, Object>
+    , Windows.Foundation.Collections.IIterable<Windows.Foundation.Collections.IKeyValuePair<String, Object> >
+  { }
 
-		Windows.Foundation.Uri ContentSourceWebLink;
-		Windows.Foundation.Uri ContentSourceApplicationLink;
-		String PackageFamilyName;
-		Windows.Storage.Streams.IRandomAccessStreamReference Square30x30Logo;
-		Windows.UI.Color LogoBackgroundColor;
+  [contract(ClipboardContract, 1.0)]
+  [uuid(6c1bd5dd-d89e-4f79-ae3b-4ad565586202)]
+  [exclusiveto(DataPackagePropertySet)]
+  [hasvariant]
+  interface IDataPackagePropertySet requires
+    Windows.Foundation.Collections.IMap<String, Object>
+    , Windows.Foundation.Collections.IIterable<Windows.Foundation.Collections.IKeyValuePair<String, Object> >
+  {
+    String Title;
+    String Description;
+    Windows.Storage.Streams.IRandomAccessStreamReference Thumbnail;
+    Windows.Foundation.Collections.IVector<String> FileTypes { get; };
+    String ApplicationName;
+    Windows.Foundation.Uri ApplicationListingUri;
 
-		String EnterpriseId;
+    Windows.Foundation.Uri ContentSourceWebLink;
+    Windows.Foundation.Uri ContentSourceApplicationLink;
+    String PackageFamilyName;
+    Windows.Storage.Streams.IRandomAccessStreamReference Square30x30Logo;
+    Windows.UI.Color LogoBackgroundColor;
 
-		String ContentSourceUserActivityJson;
-	}
+    String EnterpriseId;
 
-	[contract(ClipboardContract, 1.0)]
-	runtimeclass DataPackagePropertySetView :
-		[default] IDataPackagePropertySetView
-		, Windows.Foundation.Collections.IMapView<String, Object>
-		, Windows.Foundation.Collections.IIterable<Windows.Foundation.Collections.IKeyValuePair<String, Object> >
-	{ }
+    String ContentSourceUserActivityJson;
+  }
 
-	[contract(ClipboardContract, 1.0)]
-	[uuid(054c0bc4-ca76-4e7d-9511-4322a5a0b58b)]
-	[exclusiveto(DataPackagePropertySetView)]
-	[hasvariant]
-	interface IDataPackagePropertySetView requires
-		Windows.Foundation.Collections.IMapView<String, Object>
-		, Windows.Foundation.Collections.IIterable<Windows.Foundation.Collections.IKeyValuePair<String, Object> >
-	{
-		String Title { get; };
-		String Description { get; };
-		Windows.Storage.Streams.IRandomAccessStreamReference Thumbnail { get; };
-		Windows.Foundation.Collections.IVector<String> FileTypes { get; };
-		String ApplicationName { get; };
-		Windows.Foundation.Uri ApplicationListingUri { get; };
+  [contract(ClipboardContract, 1.0)]
+  runtimeclass DataPackagePropertySetView :
+    [default] IDataPackagePropertySetView
+    , Windows.Foundation.Collections.IMapView<String, Object>
+    , Windows.Foundation.Collections.IIterable<Windows.Foundation.Collections.IKeyValuePair<String, Object> >
+  { }
 
-		String PackageFamilyName { get; };
-		Windows.Foundation.Uri ContentSourceWebLink { get; };
-		Windows.Foundation.Uri ContentSourceApplicationLink { get; };
-		Windows.Storage.Streams.IRandomAccessStreamReference Square30x30Logo { get; };
-		Windows.UI.Color LogoBackgroundColor { get; };
+  [contract(ClipboardContract, 1.0)]
+  [uuid(054c0bc4-ca76-4e7d-9511-4322a5a0b58b)]
+  [exclusiveto(DataPackagePropertySetView)]
+  [hasvariant]
+  interface IDataPackagePropertySetView requires
+    Windows.Foundation.Collections.IMapView<String, Object>
+    , Windows.Foundation.Collections.IIterable<Windows.Foundation.Collections.IKeyValuePair<String, Object> >
+  {
+    String Title { get; };
+    String Description { get; };
+    Windows.Storage.Streams.IRandomAccessStreamReference Thumbnail { get; };
+    Windows.Foundation.Collections.IVector<String> FileTypes { get; };
+    String ApplicationName { get; };
+    Windows.Foundation.Uri ApplicationListingUri { get; };
 
-		String EnterpriseId { get; };
+    String PackageFamilyName { get; };
+    Windows.Foundation.Uri ContentSourceWebLink { get; };
+    Windows.Foundation.Uri ContentSourceApplicationLink { get; };
+    Windows.Storage.Streams.IRandomAccessStreamReference Square30x30Logo { get; };
+    Windows.UI.Color LogoBackgroundColor { get; };
 
-		String ContentSourceUserActivityJson { get; };
+    String EnterpriseId { get; };
 
-		Boolean IsFromRoamingClipboard { get; };
-	}
+    String ContentSourceUserActivityJson { get; };
 
-	[contract(ClipboardContract, 1.0)]
-	[interface_name("Microsoft.ProjectReunion.ApplicationModel.IDataPackageView", 659f7a31-3335-4e57-b373-8898ffae5ab1)]
-	runtimeclass DataPackageView
-	{
-		DataPackagePropertySetView Properties { get; };
+    Boolean IsFromRoamingClipboard { get; };
+  }
 
-		DataPackageOperation RequestedOperation { get; };
-		void ReportOperationCompleted(DataPackageOperation operation);
+  [contract(ClipboardContract, 1.0)]
+  [interface_name("Microsoft.ProjectReunion.ApplicationModel.IDataPackageView", 659f7a31-3335-4e57-b373-8898ffae5ab1)]
+  runtimeclass DataPackageView
+  {
+    DataPackagePropertySetView Properties { get; };
 
-		Windows.Foundation.Collections.IVectorView<String> AvailableFormats { get; };
-		Boolean Contains(String formatId);
+    DataPackageOperation RequestedOperation { get; };
+    void ReportOperationCompleted(DataPackageOperation operation);
 
-		Windows.Foundation.IAsyncOperation<Object> GetDataAsync(String formatId);
+    Windows.Foundation.Collections.IVectorView<String> AvailableFormats { get; };
+    Boolean Contains(String formatId);
 
-		[method_name("GetTextAsync")]
-		Windows.Foundation.IAsyncOperation<String> GetTextAsync();
-		[method_name("GetCustomTextAsync")]
-		Windows.Foundation.IAsyncOperation<String> GetTextAsync(String formatId);
+    Windows.Foundation.IAsyncOperation<Object> GetDataAsync(String formatId);
 
-		[deprecated("GetUriAsync may be altered or unavailable in future releases. Instead, use GetWebLinkAsync or GetApplicationLinkAsync.", deprecate, ClipboardContract, 1.0)]
-		Windows.Foundation.IAsyncOperation<Windows.Foundation.Uri> GetUriAsync();
-		Windows.Foundation.IAsyncOperation<String> GetHtmlFormatAsync();
-		Windows.Foundation.IAsyncOperation<Windows.Foundation.Collections.IMapView<String, Windows.Storage.Streams.RandomAccessStreamReference> > GetResourceMapAsync();
-		Windows.Foundation.IAsyncOperation<String> GetRtfAsync();
-		Windows.Foundation.IAsyncOperation<Windows.Storage.Streams.RandomAccessStreamReference> GetBitmapAsync();
-		Windows.Foundation.IAsyncOperation<Windows.Foundation.Collections.IVectorView<Windows.Storage.IStorageItem> > GetStorageItemsAsync();
+    [method_name("GetTextAsync")]
+    Windows.Foundation.IAsyncOperation<String> GetTextAsync();
+    [method_name("GetCustomTextAsync")]
+    Windows.Foundation.IAsyncOperation<String> GetTextAsync(String formatId);
 
-		Windows.Foundation.IAsyncOperation<Windows.Foundation.Uri> GetApplicationLinkAsync();
-		Windows.Foundation.IAsyncOperation<Windows.Foundation.Uri> GetWebLinkAsync();
+    [deprecated("GetUriAsync may be altered or unavailable in future releases. Instead, use GetWebLinkAsync or GetApplicationLinkAsync.", deprecate, ClipboardContract, 1.0)]
+    Windows.Foundation.IAsyncOperation<Windows.Foundation.Uri> GetUriAsync();
+    Windows.Foundation.IAsyncOperation<String> GetHtmlFormatAsync();
+    Windows.Foundation.IAsyncOperation<Windows.Foundation.Collections.IMapView<String, Windows.Storage.Streams.RandomAccessStreamReference> > GetResourceMapAsync();
+    Windows.Foundation.IAsyncOperation<String> GetRtfAsync();
+    Windows.Foundation.IAsyncOperation<Windows.Storage.Streams.RandomAccessStreamReference> GetBitmapAsync();
+    Windows.Foundation.IAsyncOperation<Windows.Foundation.Collections.IVectorView<Windows.Storage.IStorageItem> > GetStorageItemsAsync();
 
-		[method_name("RequestAccessAsync")]
-		Windows.Foundation.IAsyncOperation<Windows.Security.EnterpriseData.ProtectionPolicyEvaluationResult> RequestAccessAsync();
-		[method_name("RequestAccessWithEnterpriseIdAsync")]
-		Windows.Foundation.IAsyncOperation<Windows.Security.EnterpriseData.ProtectionPolicyEvaluationResult> RequestAccessAsync(String enterpriseId);
-		Windows.Security.EnterpriseData.ProtectionPolicyEvaluationResult UnlockAndAssumeEnterpriseIdentity();
+    Windows.Foundation.IAsyncOperation<Windows.Foundation.Uri> GetApplicationLinkAsync();
+    Windows.Foundation.IAsyncOperation<Windows.Foundation.Uri> GetWebLinkAsync();
 
-		void SetAcceptedFormatId(String formatId);
-	}
+    [method_name("RequestAccessAsync")]
+    Windows.Foundation.IAsyncOperation<Windows.Security.EnterpriseData.ProtectionPolicyEvaluationResult> RequestAccessAsync();
+    [method_name("RequestAccessWithEnterpriseIdAsync")]
+    Windows.Foundation.IAsyncOperation<Windows.Security.EnterpriseData.ProtectionPolicyEvaluationResult> RequestAccessAsync(String enterpriseId);
+    Windows.Security.EnterpriseData.ProtectionPolicyEvaluationResult UnlockAndAssumeEnterpriseIdentity();
 
-	[contract(ClipboardContract, 1.0)]
-	[interface_name("Microsoft.ProjectReunion.ApplicationModel.IDataProviderDeferral", 4f9a822c-1bb1-4c3e-b908-e202c8b87f4c)]
-	runtimeclass DataProviderDeferral
-	{
-		void Complete();
-	}
+    void SetAcceptedFormatId(String formatId);
+  }
 
-	[contract(ClipboardContract, 1.0)]
-	[interface_name("Microsoft.ProjectReunion.ApplicationModel.IDataProviderRequest", 25f2c71c-832b-4b8e-b9e9-672f098d2770)]
-	runtimeclass DataProviderRequest
-	{
-		String FormatId { get; };
-		Windows.Foundation.DateTime Deadline { get; };
-		DataProviderDeferral GetDeferral();
-		void SetData(Object value);
-	}
+  [contract(ClipboardContract, 1.0)]
+  [interface_name("Microsoft.ProjectReunion.ApplicationModel.IDataProviderDeferral", 4f9a822c-1bb1-4c3e-b908-e202c8b87f4c)]
+  runtimeclass DataProviderDeferral
+  {
+    void Complete();
+  }
 
-	[static_name("Microsoft.ProjectReunion.ApplicationModel.IHtmlFormatHelperStatics", cce26a46-4048-4fb4-99c8-b822d03cd526)]
-	static runtimeclass HtmlFormatHelper
-	{
-		static String GetStaticFragment(String htmlFormat);
-		static String CreateHtmlFormat(String htmlFragment);
-	}
+  [contract(ClipboardContract, 1.0)]
+  [interface_name("Microsoft.ProjectReunion.ApplicationModel.IDataProviderRequest", 25f2c71c-832b-4b8e-b9e9-672f098d2770)]
+  runtimeclass DataProviderRequest
+  {
+    String FormatId { get; };
+    Windows.Foundation.DateTime Deadline { get; };
+    DataProviderDeferral GetDeferral();
+    void SetData(Object value);
+  }
 
-	[contract(ClipboardContract, 1.0)]
-	[interface_name("Microsoft.ProjectReunion.ApplicationModel.IOperationCompletedEventArgs", a180ab74-fcc7-42f3-a6bd-5d373a28fc8d)]
-	runtimeclass OperationCompletedEventArgs
-	{
-		DataPackageOperation Operation { get; };
+  [static_name("Microsoft.ProjectReunion.ApplicationModel.IHtmlFormatHelperStatics", cce26a46-4048-4fb4-99c8-b822d03cd526)]
+  static runtimeclass HtmlFormatHelper
+  {
+    static String GetStaticFragment(String htmlFormat);
+    static String CreateHtmlFormat(String htmlFragment);
+  }
 
-		String AcceptedFormatId { get; };
-	}
+  [contract(ClipboardContract, 1.0)]
+  [interface_name("Microsoft.ProjectReunion.ApplicationModel.IOperationCompletedEventArgs", a180ab74-fcc7-42f3-a6bd-5d373a28fc8d)]
+  runtimeclass OperationCompletedEventArgs
+  {
+    DataPackageOperation Operation { get; };
 
-	[contract(ClipboardContract, 1.0)]
-	[static_name("Microsoft.ProjectReunion.ApplicationModel.IStandardDataFormatsStatics", 18f4cbf8-64f1-4ba1-9e64-53648a0443a8)]
-	static runtimeclass StandardDataFormats
-	{
-		static String Text { get; };
-		[deprecated("Uri may be altered or unavailable in future releases. Instead, use WebLink or ApplicationLink.", deprecate, ClipboardContract, 1.0)]
-		static String Uri { get; };
-		static String Html { get; };
-		static String Rtf { get; };
-		static String Bitmap { get; };
-		static String StorageItems { get; };
+    String AcceptedFormatId { get; };
+  }
 
-		static String WebLink { get; };
-		static String ApplicationLink { get; };
+  [contract(ClipboardContract, 1.0)]
+  [static_name("Microsoft.ProjectReunion.ApplicationModel.IStandardDataFormatsStatics", 18f4cbf8-64f1-4ba1-9e64-53648a0443a8)]
+  static runtimeclass StandardDataFormats
+  {
+    static String Text { get; };
+    [deprecated("Uri may be altered or unavailable in future releases. Instead, use WebLink or ApplicationLink.", deprecate, ClipboardContract, 1.0)]
+    static String Uri { get; };
+    static String Html { get; };
+    static String Rtf { get; };
+    static String Bitmap { get; };
+    static String StorageItems { get; };
 
-		static String UserActivityJsonArray { get; };
-	}
+    static String WebLink { get; };
+    static String ApplicationLink { get; };
+
+    static String UserActivityJsonArray { get; };
+  }
 
 }

--- a/specs/clipboard-api/clipboard.idl
+++ b/specs/clipboard-api/clipboard.idl
@@ -81,7 +81,6 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 	interface IDataTransferManagerStatics;
 	interface IDataTransferManagerStatics2;
 	interface IDataTransferManagerStatics3;
-	interface IHtmlFormatHelperStatics;
 	interface IOperationCompletedEventArgs;
 	interface IOperationCompletedEventArgs2;
 	interface IShareCompletedEventArgs;
@@ -91,10 +90,6 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 	interface IShareProvidersRequestedEventArgs;
 	interface IShareTargetInfo;
 	interface IShareUIOptions;
-	interface ISharedStorageAccessManagerStatics;
-	interface IStandardDataFormatsStatics;
-	interface IStandardDataFormatsStatics2;
-	interface IStandardDataFormatsStatics3;
 	interface ITargetApplicationChosenEventArgs;
 	runtimeclass Clipboard;
 	runtimeclass ClipboardContentOptions;
@@ -536,15 +531,6 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 	}
 
 	[contract(ClipboardContract, 1.0)]
-	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.HtmlFormatHelper)]
-	[uuid(cce26a46-4048-4fb4-99c8-b822d03cd526)]
-	interface IHtmlFormatHelperStatics : IInspectable
-	{
-		HRESULT GetStaticFragment([in] HSTRING htmlFormat, [out] [retval] HSTRING* htmlFragment);
-		HRESULT CreateHtmlFormat([in] HSTRING htmlFragment, [out] [retval] HSTRING* htmlFormat);
-	}
-
-	[contract(ClipboardContract, 1.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.OperationCompletedEventArgs)]
 	[uuid(a180ab74-fcc7-42f3-a6bd-5d373a28fc8d)]
 	interface IOperationCompletedEventArgs : IInspectable
@@ -626,46 +612,6 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 		[propput] HRESULT Theme([in] Microsoft.ProjectReunion.ApplicationModel.ShareUITheme value);
 		[propget] HRESULT SelectionRect([out] [retval] Windows.Foundation.IReference<Windows.Foundation.Rect>** value);
 		[propput] HRESULT SelectionRect([in] Windows.Foundation.IReference<Windows.Foundation.Rect>* value);
-	}
-
-	[contract(ClipboardContract, 1.0)]
-	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.SharedStorageAccessManager)]
-	[uuid(9b5b520e-1b1a-487a-be92-f214f21c255f)]
-	interface ISharedStorageAccessManagerStatics : IInspectable
-	{
-		HRESULT AddFile([in] Windows.Storage.IStorageFile* file, [out] [retval] HSTRING* outToken);
-		HRESULT RedeemTokenForFileAsync([in] HSTRING token, [out] [retval] Windows.Foundation.IAsyncOperation<Windows.Storage.StorageFile*>** operation);
-		HRESULT RemoveFile([in] HSTRING token);
-	}
-
-	[contract(ClipboardContract, 1.0)]
-	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.StandardDataFormats)]
-	[uuid(18f4cbf8-64f1-4ba1-9e64-53648a0443a8)]
-	interface IStandardDataFormatsStatics : IInspectable
-	{
-		[propget] HRESULT Text([out] [retval] HSTRING* value);
-		[deprecated("Uri may be altered or unavailable for releases after Windows Phone 'OSVersion' (TBD). Instead, use WebLink or ApplicationLink.", deprecate, ClipboardContract, 1.0)] [propget] HRESULT Uri([out] [retval] HSTRING* value);
-		[propget] HRESULT Html([out] [retval] HSTRING* value);
-		[propget] HRESULT Rtf([out] [retval] HSTRING* value);
-		[propget] HRESULT Bitmap([out] [retval] HSTRING* value);
-		[propget] HRESULT StorageItems([out] [retval] HSTRING* value);
-	}
-
-	[contract(ClipboardContract, 1.0)]
-	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.StandardDataFormats)]
-	[uuid(49fe04c9-d5f6-4416-a0cf-68a484e218b3)]
-	interface IStandardDataFormatsStatics2 : IInspectable
-	{
-		[propget] HRESULT WebLink([out] [retval] HSTRING* value);
-		[propget] HRESULT ApplicationLink([out] [retval] HSTRING* value);
-	}
-
-	[contract(ClipboardContract, 6.0)]
-	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.StandardDataFormats)]
-	[uuid(8540c4ae-3d15-44ad-9a13-59fe48f111ba)]
-	interface IStandardDataFormatsStatics3 : IInspectable
-	{
-		[propget] HRESULT UserActivityJsonArray([out] [retval] HSTRING* value);
 	}
 
 	[contract(ClipboardContract, 1.0)]
@@ -823,10 +769,11 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 	}
 
 	[contract(ClipboardContract, 1.0)]
-	[marshaling_behavior(agile)]
-	[static(Microsoft.ProjectReunion.ApplicationModel.IHtmlFormatHelperStatics, ClipboardContract, 1.0)]
+	[static_name("Microsoft.ProjectReunion.ApplicationModel.IHtmlFormatHelperStatics", cce26a46-4048-4fb4-99c8-b822d03cd526)]
 	runtimeclass HtmlFormatHelper
 	{
+		static String GetStaticFragment(String htmlFormat);
+		static String CreateHtmlFormat(String htmlFragment);
 	}
 
 	[contract(ClipboardContract, 1.0)]
@@ -883,18 +830,30 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 	}
 
 	[contract(ClipboardContract, 1.0)]
-	[static(Microsoft.ProjectReunion.ApplicationModel.ISharedStorageAccessManagerStatics, ClipboardContract, 1.0)]
+	[static_name("Microsoft.ProjectReunion.ApplicationModel.ISharedStorageAccessManagerStatics", 9b5b520e-1b1a-487a-be92-f214f21c255f)]
 	runtimeclass SharedStorageAccessManager
 	{
+		static String AddFile(Windows.Storage.IStorageFile file);
+		static Windows.Foundation.IAsyncOperation<Windows.Storage.StorageFile> RedeemTokenForFileAsync(String token);
+		static void RemoveFile(String token);
 	}
 
-	[contract(ClipboardContract, 1.0)]
-	[marshaling_behavior(agile)]
-	[static(Microsoft.ProjectReunion.ApplicationModel.IStandardDataFormatsStatics, ClipboardContract, 1.0)]
-	[static(Microsoft.ProjectReunion.ApplicationModel.IStandardDataFormatsStatics2, ClipboardContract, 1.0)]
-	[static(Microsoft.ProjectReunion.ApplicationModel.IStandardDataFormatsStatics3, ClipboardContract, 6.0)]
+	[contract(ClipboardContract, 6.0)]
+	[static_name("Microsoft.ProjectReunion.ApplicationModel.IStandardDataFormatsStatics", 18f4cbf8-64f1-4ba1-9e64-53648a0443a8)]
 	runtimeclass StandardDataFormats
 	{
+		static String Text { get; };
+		[deprecated("Uri may be altered or unavailable in later releases. Instead, use WebLink or ApplicationLink.", deprecate, ClipboardContract, 6.0)]
+		static String Uri { get; };
+		static String Html { get; };
+		static String Rtf { get; };
+		static String Bitmap { get; };
+		static String StorageItems { get; };
+
+		static String WebLink { get; };
+		static String ApplicationLink { get; };
+
+		static String UserActivityJsonArray { get; };
 	}
 
 	[contract(ClipboardContract, 1.0)]

--- a/specs/clipboard-api/clipboard.idl
+++ b/specs/clipboard-api/clipboard.idl
@@ -145,21 +145,21 @@ namespace Microsoft.ProjectReunion.ApplicationModel
   static runtimeclass Clipboard
   {
     static DataPackageView GetContent();
-    static void SetContent(DataPackage content);
 
+    static void SetContent(DataPackage content);
+    static Boolean SetContentWithOptions(DataPackage content, ClipboardContentOptions options);
     static void Flush();
     static void Clear();
 
     static event Windows.Foundation.EventHandler<Object> ContentChanged;
 
     static Windows.Foundation.IAsyncOperation<ClipboardHistoryItemsResult> GetHistoryItemsAsync();
-    static Boolean ClearHistory();
-    static Boolean DeleteItemFromHistory(ClipboardHistoryItem item);
     static SetHistoryItemAsContentStatus SetHistoryItemAsContent(ClipboardHistoryItem item);
+    static Boolean DeleteItemFromHistory(ClipboardHistoryItem item);
+    static Boolean ClearHistory();
+
     static Boolean IsHistoryEnabled();
     static Boolean IsRoamingEnabled();
-
-    static Boolean SetContentWithOptions(DataPackage content, ClipboardContentOptions options);
 
     static event Windows.Foundation.EventHandler<Object> HistoryChanged;
     static event Windows.Foundation.EventHandler<Object> RoamingEnabledChanged;
@@ -218,17 +218,20 @@ namespace Microsoft.ProjectReunion.ApplicationModel
     DataPackageView GetView();
     DataPackagePropertySet Properties { get; };
     DataPackageOperation RequestedOperation;
+
     event Windows.Foundation.TypedEventHandler<DataPackage, OperationCompletedEventArgs> OperationCompleted;
     event Windows.Foundation.TypedEventHandler<DataPackage, Object> Destroyed;
+
     void SetData(String formatId, [hasvariant] Object value);
     void SetDataProvider(String formatId, DataProviderHandler delayRenderer);
+
     void SetText(String value);
     void SetHtmlFormat(String value);
-
-    // typically used with SetHtmlFormat to include images, other secondary resources with the HTML
-    Windows.Foundation.Collections.IMap<String, Windows.Storage.Streams.RandomAccessStreamReference> ResourceMap { get; };
-
     void SetRtf(String value);
+
+    void SetApplicationLink(Windows.Foundation.Uri value);
+    void SetWebLink(Windows.Foundation.Uri value);
+
     void SetBitmap(Windows.Storage.Streams.RandomAccessStreamReference value);
 
     [method_name("SetStorageItemsReadOnly")]
@@ -236,8 +239,8 @@ namespace Microsoft.ProjectReunion.ApplicationModel
     [method_name("SetStorageItems")]
     void SetStorageItems(Windows.Foundation.Collections.IIterable<Windows.Storage.IStorageItem> value, Boolean readOnly);
 
-    void SetApplicationLink(Windows.Foundation.Uri value);
-    void SetWebLink(Windows.Foundation.Uri value);
+    /// typically used with SetHtmlFormat to include images, other secondary resources with the HTML
+    Windows.Foundation.Collections.IMap<String, Windows.Storage.Streams.RandomAccessStreamReference> ResourceMap { get; };
   }
 
   /// <summary>
@@ -260,15 +263,17 @@ namespace Microsoft.ProjectReunion.ApplicationModel
     Windows.Foundation.IAsyncOperation<String> GetTextAsync();
     [method_name("GetCustomTextAsync")]
     Windows.Foundation.IAsyncOperation<String> GetTextAsync(String formatId);
-
     Windows.Foundation.IAsyncOperation<String> GetHtmlFormatAsync();
-    Windows.Foundation.IAsyncOperation<Windows.Foundation.Collections.IMapView<String, Windows.Storage.Streams.RandomAccessStreamReference> > GetResourceMapAsync();
     Windows.Foundation.IAsyncOperation<String> GetRtfAsync();
-    Windows.Foundation.IAsyncOperation<Windows.Storage.Streams.RandomAccessStreamReference> GetBitmapAsync();
-    Windows.Foundation.IAsyncOperation<Windows.Foundation.Collections.IVectorView<Windows.Storage.IStorageItem> > GetStorageItemsAsync();
 
     Windows.Foundation.IAsyncOperation<Windows.Foundation.Uri> GetApplicationLinkAsync();
     Windows.Foundation.IAsyncOperation<Windows.Foundation.Uri> GetWebLinkAsync();
+
+    Windows.Foundation.IAsyncOperation<Windows.Storage.Streams.RandomAccessStreamReference> GetBitmapAsync();
+
+    Windows.Foundation.IAsyncOperation<Windows.Foundation.Collections.IVectorView<Windows.Storage.IStorageItem> > GetStorageItemsAsync();
+
+    Windows.Foundation.IAsyncOperation<Windows.Foundation.Collections.IMapView<String, Windows.Storage.Streams.RandomAccessStreamReference> > GetResourceMapAsync();
 
     [method_name("RequestAccessAsync")]
     Windows.Foundation.IAsyncOperation<Windows.Security.EnterpriseData.ProtectionPolicyEvaluationResult> RequestAccessAsync();

--- a/specs/clipboard-api/clipboard.idl
+++ b/specs/clipboard-api/clipboard.idl
@@ -116,6 +116,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
   [flags]
   enum DataPackageOperation
   {
+    // TODO: combine Copy and Move?
     aaaNone = 0x0,
     aaaCopy = 0x1,
     aaaMove = 0x2,
@@ -130,10 +131,19 @@ namespace Microsoft.ProjectReunion.ApplicationModel
     aaaItemDeleted  = 2,
   };
 
+  /// <summary>
+  /// Prototype for functions that will be called to render a delay-rendered
+  /// data format in a <see cref="DataPackage"/>.
+  /// </summary>
   [contract(ClipboardContract, 1.0)]
   [uuid(6d9e7bfb-3280-4219-be29-08145f30f4e5)]
   delegate void DataProviderHandler(DataProviderRequest request);
 
+  /// <summary>
+  /// Top-level API for reading, writing, and monitoring the system clipboard
+  /// and clipboard history, if available. Clipboard history also
+  /// includes clipboard items roamed from your other devices through the cloud.
+  /// </summary>
   [contract(ClipboardContract, 1.0)]
   [static_name("Microsoft.ProjectReunion.ApplicationModel.IClipboardStatics", 6cb53030-4da0-43a1-95ab-52f87cf59c3a)]
   [marshaling_behavior(standard)]
@@ -161,6 +171,9 @@ namespace Microsoft.ProjectReunion.ApplicationModel
     static event Windows.Foundation.EventHandler<Object> HistoryEnabledChanged;
   }
 
+  /// <summary>
+  /// Settings your app can set for a new item it cuts or copies onto the clipboard.
+  /// </summary>
   [contract(ClipboardContract, 1.0)]
   [interface_name("Microsoft.ProjectReunion.ApplicationModel.IClipboardContentOptions", c31b927f-1008-4e98-b575-adf175ccdd0b)]
   runtimeclass ClipboardContentOptions
@@ -173,11 +186,18 @@ namespace Microsoft.ProjectReunion.ApplicationModel
     Windows.Foundation.Collections.IVector<String> HistoryFormats { get; };
   }
 
+  /// <summary>
+  /// Input parameters for the <see cref="Clipboard.HistoryChanged"/> event.
+  /// </summary>
+  // TO CONSIDER: should this class be omitted since it was empty in-box?
   [contract(ClipboardContract, 1.0)]
   [interface_name("Microsoft.ProjectReunion.ApplicationModel.IClipboardHistoryChangedEventArgs", 9d1960c7-cf0a-4e51-943c-72373b7a2579)]
   runtimeclass ClipboardHistoryChangedEventArgs
   { }
 
+  /// <summary>
+  /// An item retrieved from the clipboard history log.
+  /// </summary>
   [contract(ClipboardContract, 1.0)]
   [interface_name("Microsoft.ProjectReunion.ApplicationModel.IClipboardHistoryItem", 1907eff8-7d2f-4a71-8a56-bd02effeb184)]
   runtimeclass ClipboardHistoryItem
@@ -187,6 +207,9 @@ namespace Microsoft.ProjectReunion.ApplicationModel
     DataPackageView Content { get; };
   }
 
+  /// <summary>
+  /// Return value for a call to <see cref="Clipboard.GetHistoryItemsAsync"/>.
+  /// </summary>
   [contract(ClipboardContract, 1.0)]
   [interface_name("Microsoft.ProjectReunion.ApplicationModel.IClipboardHistoryItemsResult", 2f6c9705-f56b-42f0-b1a1-fc2d46d572e7)]
   runtimeclass ClipboardHistoryItemsResult
@@ -195,6 +218,13 @@ namespace Microsoft.ProjectReunion.ApplicationModel
     Windows.Foundation.Collections.IVectorView<ClipboardHistoryItem> Items { get; };
   }
 
+  /// <summary>
+  /// Basic unit of data transfer for <see cref="Clipboard"/>.
+  /// Allows data to be sent in multiple "formats". Certain formats can be
+  /// "delay rendered", meaning they are not serialized immediately into
+  /// the DataPackage but instead a creator-provided callback will
+  /// serialize them on demand.
+  /// </summary>
   [contract(ClipboardContract, 1.0)]
   [interface_name("Microsoft.ProjectReunion.ApplicationModel.IDataPackage", 36861532-b01e-49c5-9a0b-2282d079c9ac)]
   runtimeclass DataPackage
@@ -213,6 +243,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
     void SetUri(Windows.Foundation.Uri value);
     void SetHtmlFormat(String value);
 
+    // typically used with SetHtmlFormat to include images, other secondary resources with the HTML
     Windows.Foundation.Collections.IMap<String, Windows.Storage.Streams.RandomAccessStreamReference> ResourceMap { get; };
 
     void SetRtf(String value);
@@ -227,74 +258,9 @@ namespace Microsoft.ProjectReunion.ApplicationModel
     void SetWebLink(Windows.Foundation.Uri value);
   }
 
-  [contract(ClipboardContract, 1.0)]
-  runtimeclass DataPackagePropertySet :
-    [default] IDataPackagePropertySet
-    , Windows.Foundation.Collections.IMap<String, Object>
-    , Windows.Foundation.Collections.IIterable<Windows.Foundation.Collections.IKeyValuePair<String, Object> >
-  { }
-
-  [contract(ClipboardContract, 1.0)]
-  [uuid(6c1bd5dd-d89e-4f79-ae3b-4ad565586202)]
-  [exclusiveto(DataPackagePropertySet)]
-  [hasvariant]
-  interface IDataPackagePropertySet requires
-    Windows.Foundation.Collections.IMap<String, Object>
-    , Windows.Foundation.Collections.IIterable<Windows.Foundation.Collections.IKeyValuePair<String, Object> >
-  {
-    String Title;
-    String Description;
-    Windows.Storage.Streams.IRandomAccessStreamReference Thumbnail;
-    Windows.Foundation.Collections.IVector<String> FileTypes { get; };
-    String ApplicationName;
-    Windows.Foundation.Uri ApplicationListingUri;
-
-    Windows.Foundation.Uri ContentSourceWebLink;
-    Windows.Foundation.Uri ContentSourceApplicationLink;
-    String PackageFamilyName;
-    Windows.Storage.Streams.IRandomAccessStreamReference Square30x30Logo;
-    Windows.UI.Color LogoBackgroundColor;
-
-    String EnterpriseId;
-
-    String ContentSourceUserActivityJson;
-  }
-
-  [contract(ClipboardContract, 1.0)]
-  runtimeclass DataPackagePropertySetView :
-    [default] IDataPackagePropertySetView
-    , Windows.Foundation.Collections.IMapView<String, Object>
-    , Windows.Foundation.Collections.IIterable<Windows.Foundation.Collections.IKeyValuePair<String, Object> >
-  { }
-
-  [contract(ClipboardContract, 1.0)]
-  [uuid(054c0bc4-ca76-4e7d-9511-4322a5a0b58b)]
-  [exclusiveto(DataPackagePropertySetView)]
-  [hasvariant]
-  interface IDataPackagePropertySetView requires
-    Windows.Foundation.Collections.IMapView<String, Object>
-    , Windows.Foundation.Collections.IIterable<Windows.Foundation.Collections.IKeyValuePair<String, Object> >
-  {
-    String Title { get; };
-    String Description { get; };
-    Windows.Storage.Streams.IRandomAccessStreamReference Thumbnail { get; };
-    Windows.Foundation.Collections.IVector<String> FileTypes { get; };
-    String ApplicationName { get; };
-    Windows.Foundation.Uri ApplicationListingUri { get; };
-
-    String PackageFamilyName { get; };
-    Windows.Foundation.Uri ContentSourceWebLink { get; };
-    Windows.Foundation.Uri ContentSourceApplicationLink { get; };
-    Windows.Storage.Streams.IRandomAccessStreamReference Square30x30Logo { get; };
-    Windows.UI.Color LogoBackgroundColor { get; };
-
-    String EnterpriseId { get; };
-
-    String ContentSourceUserActivityJson { get; };
-
-    Boolean IsFromRoamingClipboard { get; };
-  }
-
+  /// <summary>
+  /// Read-only view of a <see cref="DataPackage"/>.
+  /// </summary>
   [contract(ClipboardContract, 1.0)]
   [interface_name("Microsoft.ProjectReunion.ApplicationModel.IDataPackageView", 659f7a31-3335-4e57-b373-8898ffae5ab1)]
   runtimeclass DataPackageView
@@ -331,9 +297,90 @@ namespace Microsoft.ProjectReunion.ApplicationModel
     Windows.Foundation.IAsyncOperation<Windows.Security.EnterpriseData.ProtectionPolicyEvaluationResult> RequestAccessAsync(String enterpriseId);
     Windows.Security.EnterpriseData.ProtectionPolicyEvaluationResult UnlockAndAssumeEnterpriseIdentity();
 
+    // FIXME: poorly documented on docs.microsoft.com - what does it do? why is in a View class?
     void SetAcceptedFormatId(String formatId);
   }
 
+  /// <summary>
+  /// A set of metadata properties for a <see cref="DataPackage"/>.
+  /// Contains strongly-typed WinRT properties for common descriptors
+  /// of the data or source app, but also allows setting arbitrary key-value mappings.
+  /// </summary>
+  [contract(ClipboardContract, 1.0)]
+  runtimeclass DataPackagePropertySet :
+    [default] IDataPackagePropertySet
+    , Windows.Foundation.Collections.IMap<String, Object>
+    , Windows.Foundation.Collections.IIterable<Windows.Foundation.Collections.IKeyValuePair<String, Object> >
+  { }
+
+  [contract(ClipboardContract, 1.0)]
+  [uuid(6c1bd5dd-d89e-4f79-ae3b-4ad565586202)]
+  [exclusiveto(DataPackagePropertySet)]
+  [hasvariant]
+  interface IDataPackagePropertySet requires
+    Windows.Foundation.Collections.IMap<String, Object>
+    , Windows.Foundation.Collections.IIterable<Windows.Foundation.Collections.IKeyValuePair<String, Object> >
+  {
+    String Title;
+    String Description;
+    Windows.Storage.Streams.IRandomAccessStreamReference Thumbnail;
+    Windows.Foundation.Collections.IVector<String> FileTypes { get; };
+    String ApplicationName;
+    Windows.Foundation.Uri ApplicationListingUri;
+
+    Windows.Foundation.Uri ContentSourceWebLink;
+    Windows.Foundation.Uri ContentSourceApplicationLink;
+    String PackageFamilyName;
+    Windows.Storage.Streams.IRandomAccessStreamReference Square30x30Logo;
+    Windows.UI.Color LogoBackgroundColor;
+
+    String EnterpriseId;
+
+    String ContentSourceUserActivityJson;
+  }
+
+  /// <summary>
+  /// Read-only view of a <see cref="DataPackagePropertySet"/>.
+  /// </summary>
+  [contract(ClipboardContract, 1.0)]
+  runtimeclass DataPackagePropertySetView :
+    [default] IDataPackagePropertySetView
+    , Windows.Foundation.Collections.IMapView<String, Object>
+    , Windows.Foundation.Collections.IIterable<Windows.Foundation.Collections.IKeyValuePair<String, Object> >
+  { }
+
+  [contract(ClipboardContract, 1.0)]
+  [uuid(054c0bc4-ca76-4e7d-9511-4322a5a0b58b)]
+  [exclusiveto(DataPackagePropertySetView)]
+  [hasvariant]
+  interface IDataPackagePropertySetView requires
+    Windows.Foundation.Collections.IMapView<String, Object>
+    , Windows.Foundation.Collections.IIterable<Windows.Foundation.Collections.IKeyValuePair<String, Object> >
+  {
+    String Title { get; };
+    String Description { get; };
+    Windows.Storage.Streams.IRandomAccessStreamReference Thumbnail { get; };
+    Windows.Foundation.Collections.IVectorView<String> FileTypes { get; };
+    String ApplicationName { get; };
+    Windows.Foundation.Uri ApplicationListingUri { get; };
+
+    String PackageFamilyName { get; };
+    Windows.Foundation.Uri ContentSourceWebLink { get; };
+    Windows.Foundation.Uri ContentSourceApplicationLink { get; };
+    Windows.Storage.Streams.IRandomAccessStreamReference Square30x30Logo { get; };
+    Windows.UI.Color LogoBackgroundColor { get; };
+
+    String EnterpriseId { get; };
+
+    String ContentSourceUserActivityJson { get; };
+
+    Boolean IsFromRoamingClipboard { get; };
+  }
+
+  /// <summary>
+  /// An acknowledgement by the system that your app is in the process of
+  /// a delay rendering, with the ability to signal the system when done.
+  /// </summary>
   [contract(ClipboardContract, 1.0)]
   [interface_name("Microsoft.ProjectReunion.ApplicationModel.IDataProviderDeferral", 4f9a822c-1bb1-4c3e-b908-e202c8b87f4c)]
   runtimeclass DataProviderDeferral
@@ -341,6 +388,9 @@ namespace Microsoft.ProjectReunion.ApplicationModel
     void Complete();
   }
 
+  /// <summary>
+  /// Input to a <see cref="DataProviderHandler"/> function for delay-rendering.
+  /// </summary>
   [contract(ClipboardContract, 1.0)]
   [interface_name("Microsoft.ProjectReunion.ApplicationModel.IDataProviderRequest", 25f2c71c-832b-4b8e-b9e9-672f098d2770)]
   runtimeclass DataProviderRequest
@@ -351,6 +401,11 @@ namespace Microsoft.ProjectReunion.ApplicationModel
     void SetData(Object value);
   }
 
+  /// <summary>
+  /// Translates strings containing fragments of HTML to and from the special format
+  /// used by <see cref="StandardDataFormats.Html"/>, described here:
+  /// https://docs.microsoft.com/windows/win32/dataxchg/html-clipboard-format
+  /// </summary>
   [static_name("Microsoft.ProjectReunion.ApplicationModel.IHtmlFormatHelperStatics", cce26a46-4048-4fb4-99c8-b822d03cd526)]
   static runtimeclass HtmlFormatHelper
   {
@@ -358,6 +413,9 @@ namespace Microsoft.ProjectReunion.ApplicationModel
     static String CreateHtmlFormat(String htmlFragment);
   }
 
+  /// <summary>
+  /// Input parameters for <see cref="DataPackage.OperationCompleted"/> event handler functions.
+  /// </summary>
   [contract(ClipboardContract, 1.0)]
   [interface_name("Microsoft.ProjectReunion.ApplicationModel.IOperationCompletedEventArgs", a180ab74-fcc7-42f3-a6bd-5d373a28fc8d)]
   runtimeclass OperationCompletedEventArgs
@@ -367,6 +425,10 @@ namespace Microsoft.ProjectReunion.ApplicationModel
     String AcceptedFormatId { get; };
   }
 
+  /// <summary>
+  /// Static string-valued properties corresponding to data format IDs known
+  /// to the <see cref="DataPackage"/> system.
+  /// </summary>
   [contract(ClipboardContract, 1.0)]
   [static_name("Microsoft.ProjectReunion.ApplicationModel.IStandardDataFormatsStatics", 18f4cbf8-64f1-4ba1-9e64-53648a0443a8)]
   static runtimeclass StandardDataFormats

--- a/specs/clipboard-api/clipboard.idl
+++ b/specs/clipboard-api/clipboard.idl
@@ -239,8 +239,6 @@ namespace Microsoft.ProjectReunion.ApplicationModel
     void SetData(String formatId, [hasvariant] Object value);
     void SetDataProvider(String formatId, DataProviderHandler delayRenderer);
     void SetText(String value);
-    [deprecated("SetUri may be altered or unavailable in future releases. Instead, use SetWebLink or SetApplicationLink.", deprecate, ClipboardContract, 1.0)]
-    void SetUri(Windows.Foundation.Uri value);
     void SetHtmlFormat(String value);
 
     // typically used with SetHtmlFormat to include images, other secondary resources with the HTML
@@ -280,8 +278,6 @@ namespace Microsoft.ProjectReunion.ApplicationModel
     [method_name("GetCustomTextAsync")]
     Windows.Foundation.IAsyncOperation<String> GetTextAsync(String formatId);
 
-    [deprecated("GetUriAsync may be altered or unavailable in future releases. Instead, use GetWebLinkAsync or GetApplicationLinkAsync.", deprecate, ClipboardContract, 1.0)]
-    Windows.Foundation.IAsyncOperation<Windows.Foundation.Uri> GetUriAsync();
     Windows.Foundation.IAsyncOperation<String> GetHtmlFormatAsync();
     Windows.Foundation.IAsyncOperation<Windows.Foundation.Collections.IMapView<String, Windows.Storage.Streams.RandomAccessStreamReference> > GetResourceMapAsync();
     Windows.Foundation.IAsyncOperation<String> GetRtfAsync();
@@ -434,8 +430,6 @@ namespace Microsoft.ProjectReunion.ApplicationModel
   static runtimeclass StandardDataFormats
   {
     static String Text { get; };
-    [deprecated("Uri may be altered or unavailable in future releases. Instead, use WebLink or ApplicationLink.", deprecate, ClipboardContract, 1.0)]
-    static String Uri { get; };
     static String Html { get; };
     static String Rtf { get; };
     static String Bitmap { get; };

--- a/specs/clipboard-api/clipboard.idl
+++ b/specs/clipboard-api/clipboard.idl
@@ -50,10 +50,6 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 	typedef enum ShareUITheme ShareUITheme;
 	delegate DataProviderHandler;
 	delegate ShareProviderHandler;
-	interface IClipboardContentOptions;
-	interface IClipboardHistoryChangedEventArgs;
-	interface IClipboardHistoryItem;
-	interface IClipboardHistoryItemsResult;
 	interface IDataPackage;
 	interface IDataPackage2;
 	interface IDataPackage3;
@@ -81,8 +77,6 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 	interface IDataTransferManagerStatics;
 	interface IDataTransferManagerStatics2;
 	interface IDataTransferManagerStatics3;
-	interface IOperationCompletedEventArgs;
-	interface IOperationCompletedEventArgs2;
 	interface IShareCompletedEventArgs;
 	interface IShareProvider;
 	interface IShareProviderFactory;
@@ -193,45 +187,6 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 	[uuid(0d89ad1d-bb56-43e0-89d3-df5f85af2dd6)]
 	delegate
 		HRESULT ShareProviderHandler([in] Microsoft.ProjectReunion.ApplicationModel.ShareProviderOperation* operation);
-
-	[contract(ClipboardContract, 7.0)]
-	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.ClipboardContentOptions)]
-	[uuid(c31b927f-1008-4e98-b575-adf175ccdd0b)]
-	interface IClipboardContentOptions : IInspectable
-	{
-		[propget] HRESULT IsRoamable([out] [retval] boolean* value);
-		[propput] HRESULT IsRoamable([in] boolean value);
-		[propget] HRESULT IsAllowedInHistory([out] [retval] boolean* value);
-		[propput] HRESULT IsAllowedInHistory([in] boolean value);
-		[propget] HRESULT RoamingFormats([out] [retval] Windows.Foundation.Collections.IVector<HSTRING>** value);
-		[propget] HRESULT HistoryFormats([out] [retval] Windows.Foundation.Collections.IVector<HSTRING>** value);
-	}
-
-	[contract(ClipboardContract, 7.0)]
-	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.ClipboardHistoryChangedEventArgs)]
-	[uuid(9d1960c7-cf0a-4e51-943c-72373b7a2579)]
-	interface IClipboardHistoryChangedEventArgs : IInspectable
-	{
-	}
-
-	[contract(ClipboardContract, 7.0)]
-	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.ClipboardHistoryItem)]
-	[uuid(1907eff8-7d2f-4a71-8a56-bd02effeb184)]
-	interface IClipboardHistoryItem : IInspectable
-	{
-		[propget] HRESULT Id([out] [retval] HSTRING* value);
-		[propget] HRESULT Timestamp([out] [retval] Windows.Foundation.DateTime* value);
-		[propget] HRESULT Content([out] [retval] Microsoft.ProjectReunion.ApplicationModel.DataPackageView** value);
-	}
-
-	[contract(ClipboardContract, 7.0)]
-	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.ClipboardHistoryItemsResult)]
-	[uuid(2f6c9705-f56b-42f0-b1a1-fc2d46d572e7)]
-	interface IClipboardHistoryItemsResult : IInspectable
-	{
-		[propget] HRESULT Status([out] [retval] Microsoft.ProjectReunion.ApplicationModel.ClipboardHistoryItemsResultStatus* value);
-		[propget] HRESULT Items([out] [retval] Windows.Foundation.Collections.IVectorView<Microsoft.ProjectReunion.ApplicationModel.ClipboardHistoryItem*>** value);
-	}
 
 	[contract(ClipboardContract, 1.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataPackage)]
@@ -530,22 +485,6 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 		[overload("ShowShareUI")] HRESULT ShowShareUIWithOptions([in] Microsoft.ProjectReunion.ApplicationModel.ShareUIOptions* options);
 	}
 
-	[contract(ClipboardContract, 1.0)]
-	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.OperationCompletedEventArgs)]
-	[uuid(a180ab74-fcc7-42f3-a6bd-5d373a28fc8d)]
-	interface IOperationCompletedEventArgs : IInspectable
-	{
-		[propget] HRESULT Operation([out] [retval] Microsoft.ProjectReunion.ApplicationModel.DataPackageOperation* value);
-	}
-
-	[contract(ClipboardContract, 2.0)]
-	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.OperationCompletedEventArgs)]
-	[uuid(42d44094-eebc-4e52-b98b-7d0bb646a96f)]
-	interface IOperationCompletedEventArgs2 : IInspectable
-	{
-		[propget] HRESULT AcceptedFormatId([out] [retval] HSTRING* value);
-	}
-
 	[contract(ClipboardContract, 4.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.ShareCompletedEventArgs)]
 	[uuid(5107a2a6-6dd3-491a-8f1a-93a1867afa56)]
@@ -625,12 +564,14 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 	[contract(ClipboardContract, 7.0)]
 	[static_name("Microsoft.ProjectReunion.ApplicationModel.IClipboardStatics", 6cb53030-4da0-43a1-95ab-52f87cf59c3a)]
 	[marshaling_behavior(standard)]
-	runtimeclass Clipboard
+	static runtimeclass Clipboard
 	{
 		static DataPackageView GetContent();
 		static void SetContent(DataPackage content);
+
 		static void Flush();
 		static void Clear();
+
 		static event Windows.Foundation.EventHandler<Object> ContentChanged;
 
 		static Windows.Foundation.IAsyncOperation<ClipboardHistoryItemsResult> GetHistoryItemsAsync();
@@ -639,40 +580,47 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 		static SetHistoryItemAsContentStatus SetHistoryItemAsContent(ClipboardHistoryItem item);
 		static Boolean IsHistoryEnabled();
 		static Boolean IsRoamingEnabled();
+
 		static Boolean SetContentWithOptions(DataPackage content, ClipboardContentOptions options);
+
 		static event Windows.Foundation.EventHandler<ClipboardHistoryChangedEventArgs> HistoryChanged;
 		static event Windows.Foundation.EventHandler<Object> RoamingEnabledChanged;
 		static event Windows.Foundation.EventHandler<Object> HistoryEnabledChanged;
 	}
 
-	[activatable(ClipboardContract, 7.0)]
 	[contract(ClipboardContract, 7.0)]
-	[marshaling_behavior(agile)]
-	[threading(both)]
+	[interface_name("Microsoft.ProjectReunion.ApplicationModel.IClipboardContentOptions", c31b927f-1008-4e98-b575-adf175ccdd0b)]
 	runtimeclass ClipboardContentOptions
 	{
-		[default] interface Microsoft.ProjectReunion.ApplicationModel.IClipboardContentOptions;
+		ClipboardContentOptions();
+	
+		Boolean IsRoamable;
+		Boolean IsAllowedInHistory;
+		Windows.Foundation.Collections.IVector<String> RoamingFormats { get; };
+		Windows.Foundation.Collections.IVector<String> HistoryFormats { get; };
 	}
 
 	[contract(ClipboardContract, 7.0)]
-	[marshaling_behavior(agile)]
+	[interface_name("Microsoft.ProjectReunion.ApplicationModel.IClipboardHistoryChangedEventArgs", 9d1960c7-cf0a-4e51-943c-72373b7a2579)]
 	runtimeclass ClipboardHistoryChangedEventArgs
 	{
-		[default] interface Microsoft.ProjectReunion.ApplicationModel.IClipboardHistoryChangedEventArgs;
 	}
 
 	[contract(ClipboardContract, 7.0)]
-	[marshaling_behavior(agile)]
+	[interface_name("Microsoft.ProjectReunion.ApplicationModel.IClipboardHistoryItem", 1907eff8-7d2f-4a71-8a56-bd02effeb184)]
 	runtimeclass ClipboardHistoryItem
 	{
-		[default] interface Microsoft.ProjectReunion.ApplicationModel.IClipboardHistoryItem;
+		String Id { get; };
+		Windows.Foundation.DateTime Timestamp { get; };
+		DataPackageView Content { get; };
 	}
 
 	[contract(ClipboardContract, 7.0)]
-	[marshaling_behavior(agile)]
+	[interface_name("Microsoft.ProjectReunion.ApplicationModel.IClipboardHistoryItemsResult", 2f6c9705-f56b-42f0-b1a1-fc2d46d572e7)]
 	runtimeclass ClipboardHistoryItemsResult
 	{
-		[default] interface Microsoft.ProjectReunion.ApplicationModel.IClipboardHistoryItemsResult;
+		ClipboardHistoryItemsResultStatus Status { get; };
+		Windows.Foundation.Collections.IVectorView<ClipboardHistoryItem> Items { get; };
 	}
 
 	[activatable(ClipboardContract, 1.0)]
@@ -770,18 +718,19 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 
 	[contract(ClipboardContract, 1.0)]
 	[static_name("Microsoft.ProjectReunion.ApplicationModel.IHtmlFormatHelperStatics", cce26a46-4048-4fb4-99c8-b822d03cd526)]
-	runtimeclass HtmlFormatHelper
+	static runtimeclass HtmlFormatHelper
 	{
 		static String GetStaticFragment(String htmlFormat);
 		static String CreateHtmlFormat(String htmlFragment);
 	}
 
-	[contract(ClipboardContract, 1.0)]
-	[marshaling_behavior(agile)]
+	[contract(ClipboardContract, 2.0)]
+	[interface_name("Microsoft.ProjectReunion.ApplicationModel.IOperationCompletedEventArgs", a180ab74-fcc7-42f3-a6bd-5d373a28fc8d)]
 	runtimeclass OperationCompletedEventArgs
 	{
-		[default] interface Microsoft.ProjectReunion.ApplicationModel.IOperationCompletedEventArgs;
-		[contract(ClipboardContract, 2.0)] interface Microsoft.ProjectReunion.ApplicationModel.IOperationCompletedEventArgs2;
+		DataPackageOperation Operation { get; };
+		
+		String AcceptedFormatId { get; };
 	}
 
 	[contract(ClipboardContract, 4.0)]
@@ -831,7 +780,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 
 	[contract(ClipboardContract, 1.0)]
 	[static_name("Microsoft.ProjectReunion.ApplicationModel.ISharedStorageAccessManagerStatics", 9b5b520e-1b1a-487a-be92-f214f21c255f)]
-	runtimeclass SharedStorageAccessManager
+	static runtimeclass SharedStorageAccessManager
 	{
 		static String AddFile(Windows.Storage.IStorageFile file);
 		static Windows.Foundation.IAsyncOperation<Windows.Storage.StorageFile> RedeemTokenForFileAsync(String token);
@@ -840,7 +789,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 
 	[contract(ClipboardContract, 6.0)]
 	[static_name("Microsoft.ProjectReunion.ApplicationModel.IStandardDataFormatsStatics", 18f4cbf8-64f1-4ba1-9e64-53648a0443a8)]
-	runtimeclass StandardDataFormats
+	static runtimeclass StandardDataFormats
 	{
 		static String Text { get; };
 		[deprecated("Uri may be altered or unavailable in later releases. Instead, use WebLink or ApplicationLink.", deprecate, ClipboardContract, 6.0)]

--- a/specs/clipboard-api/clipboard.idl
+++ b/specs/clipboard-api/clipboard.idl
@@ -5,10 +5,12 @@ import "AsyncInfo.idl";
 import "EventToken.idl";
 import "windowscontracts.idl";
 import "Windows.Foundation.idl";
+import "Windows.Foundation.Metadata.idl";
 import "Windows.Security.EnterpriseData.idl";
 import "Windows.Storage.idl";
 import "Windows.Storage.Streams.idl";
 import "Windows.UI.idl";
+#include <sdkddkver.h>
 
 // Forward Declare
 namespace Windows.Foundation
@@ -17,6 +19,16 @@ namespace Windows.Foundation
 	runtimeclass Deferral;
 	typedef struct Rect Rect;
 	runtimeclass Uri;
+}
+
+namespace Windows.Foundation.Metadata
+{
+	[attributeusage(target_all)]
+	[attributename("hasvariant")]
+	[version(NTDDI_WIN8)]
+	attribute HasVariantAttribute
+	{
+	}
 }
 
 namespace Windows.Security.EnterpriseData
@@ -50,10 +62,6 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 	typedef enum ShareUITheme ShareUITheme;
 	delegate DataProviderHandler;
 	delegate ShareProviderHandler;
-	interface IDataPackage;
-	interface IDataPackage2;
-	interface IDataPackage3;
-	interface IDataPackage4;
 	interface IDataPackagePropertySet;
 	interface IDataPackagePropertySet2;
 	interface IDataPackagePropertySet3;
@@ -187,58 +195,6 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 	[uuid(0d89ad1d-bb56-43e0-89d3-df5f85af2dd6)]
 	delegate
 		HRESULT ShareProviderHandler([in] Microsoft.ProjectReunion.ApplicationModel.ShareProviderOperation* operation);
-
-	[contract(ClipboardContract, 1.0)]
-	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataPackage)]
-	[uuid(36861532-b01e-49c5-9a0b-2282d079c9ac)]
-	interface IDataPackage : IInspectable
-	{
-		HRESULT GetView([out] [retval] Microsoft.ProjectReunion.ApplicationModel.DataPackageView** result);
-		[propget] HRESULT Properties([out] [retval] Microsoft.ProjectReunion.ApplicationModel.DataPackagePropertySet** value);
-		[propget] HRESULT RequestedOperation([out] [retval] Microsoft.ProjectReunion.ApplicationModel.DataPackageOperation* value);
-		[propput] HRESULT RequestedOperation([in] Microsoft.ProjectReunion.ApplicationModel.DataPackageOperation value);
-		[eventadd] HRESULT OperationCompleted([in] Windows.Foundation.TypedEventHandler<Microsoft.ProjectReunion.ApplicationModel.DataPackage*, Microsoft.ProjectReunion.ApplicationModel.OperationCompletedEventArgs*>* handler, [out] [retval] EventRegistrationToken* token);
-		[eventremove] HRESULT OperationCompleted([in] EventRegistrationToken token);
-		[eventadd] HRESULT Destroyed([in] Windows.Foundation.TypedEventHandler<Microsoft.ProjectReunion.ApplicationModel.DataPackage*, IInspectable*>* handler, [out] [retval] EventRegistrationToken* token);
-		[eventremove] HRESULT Destroyed([in] EventRegistrationToken token);
-		HRESULT SetData([in] HSTRING formatId, [in] IInspectable* value);
-		HRESULT SetDataProvider([in] HSTRING formatId, [in] Microsoft.ProjectReunion.ApplicationModel.DataProviderHandler* delayRenderer);
-		HRESULT SetText([in] HSTRING value);
-		[deprecated("SetUri may be altered or unavailable for releases after Windows Phone 'OSVersion' (TBD).Instead, use SetWebLink or SetApplicationLink.", deprecate, ClipboardContract, 1.0)] HRESULT SetUri([in] Windows.Foundation.Uri* value);
-		HRESULT SetHtmlFormat([in] HSTRING value);
-		[propget] HRESULT ResourceMap([out] [retval] Windows.Foundation.Collections.IMap<HSTRING, Windows.Storage.Streams.RandomAccessStreamReference*>** value);
-		HRESULT SetRtf([in] HSTRING value);
-		HRESULT SetBitmap([in] Windows.Storage.Streams.RandomAccessStreamReference* value);
-		[overload("SetStorageItems")] HRESULT SetStorageItemsReadOnly([in] Windows.Foundation.Collections.IIterable<Windows.Storage.IStorageItem*>* value);
-		[overload("SetStorageItems")] HRESULT SetStorageItems([in] Windows.Foundation.Collections.IIterable<Windows.Storage.IStorageItem*>* value, [in] boolean readOnly);
-	}
-
-	[contract(ClipboardContract, 1.0)]
-	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataPackage)]
-	[uuid(9f8a2f2b-3602-48ec-b0dd-4d7f754da3b2)]
-	interface IDataPackage2 : IInspectable
-	{
-		HRESULT SetApplicationLink([in] Windows.Foundation.Uri* value);
-		HRESULT SetWebLink([in] Windows.Foundation.Uri* value);
-	}
-
-	[contract(ClipboardContract, 4.0)]
-	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataPackage)]
-	[uuid(670dbf2f-9f0e-4ed9-a3f3-775fb0cd2134)]
-	interface IDataPackage3 : IInspectable
-	{
-		[eventadd] HRESULT ShareCompleted([in] Windows.Foundation.TypedEventHandler<Microsoft.ProjectReunion.ApplicationModel.DataPackage*, Microsoft.ProjectReunion.ApplicationModel.ShareCompletedEventArgs*>* handler, [out] [retval] EventRegistrationToken* token);
-		[eventremove] HRESULT ShareCompleted([in] EventRegistrationToken token);
-	}
-
-	[contract(ClipboardContract, 10.0)]
-	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataPackage)]
-	[uuid(fd923204-3d54-4fd2-b1fc-607984c97f43)]
-	interface IDataPackage4 : IInspectable
-	{
-		[eventadd] HRESULT ShareCanceled([in] Windows.Foundation.TypedEventHandler<Microsoft.ProjectReunion.ApplicationModel.DataPackage*, IInspectable*>* handler, [out] [retval] EventRegistrationToken* token);
-		[eventremove] HRESULT ShareCanceled([in] EventRegistrationToken token);
-	}
 
 	[contract(ClipboardContract, 1.0)]
 	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataPackagePropertySet)]
@@ -623,16 +579,40 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 		Windows.Foundation.Collections.IVectorView<ClipboardHistoryItem> Items { get; };
 	}
 
-	[activatable(ClipboardContract, 1.0)]
-	[contract(ClipboardContract, 1.0)]
-	[marshaling_behavior(agile)]
-	[threading(both)]
+	[contract(ClipboardContract, 10.0)]
+	[interface_name("Microsoft.ProjectReunion.ApplicationModel.IDataPackage", 36861532-b01e-49c5-9a0b-2282d079c9ac)]
 	runtimeclass DataPackage
 	{
-		[default] interface Microsoft.ProjectReunion.ApplicationModel.IDataPackage;
-		[contract(ClipboardContract, 1.0)] interface Microsoft.ProjectReunion.ApplicationModel.IDataPackage2;
-		[contract(ClipboardContract, 4.0)] interface Microsoft.ProjectReunion.ApplicationModel.IDataPackage3;
-		[contract(ClipboardContract, 10.0)] interface Microsoft.ProjectReunion.ApplicationModel.IDataPackage4;
+		DataPackage();
+
+		DataPackageView GetView();
+		DataPackagePropertySet Properties { get; };
+		DataPackageOperation RequestedOperation;
+		event Windows.Foundation.TypedEventHandler<DataPackage, OperationCompletedEventArgs> OperationCompleted;
+		event Windows.Foundation.TypedEventHandler<DataPackage, Object> Destroyed;
+		void SetData(String formatId, [hasvariant] Object value);
+		void SetDataProvider(String formatId, DataProviderHandler delayRenderer);
+		void SetText(String value);
+		[deprecated("SetUri may be altered or unavailable in later releases. Instead, use SetWebLink or SetApplicationLink.", deprecate, ClipboardContract, 10.0)]
+		void SetUri(Windows.Foundation.Uri value);
+		void SetHtmlFormat(String value);
+
+		Windows.Foundation.Collections.IMap<String, Windows.Storage.Streams.RandomAccessStreamReference> ResourceMap { get; };
+
+		void SetRtf(String value);
+		void SetBitmap(Windows.Storage.Streams.RandomAccessStreamReference value);
+
+		[method_name("SetStorageItemsReadOnly")]
+		void SetStorageItems(Windows.Foundation.Collections.IIterable<Windows.Storage.IStorageItem> value);
+		[method_name("SetStorageItems")]
+		void SetStorageItems(Windows.Foundation.Collections.IIterable<Windows.Storage.IStorageItem> value, Boolean readOnly);
+
+		void SetApplicationLink(Windows.Foundation.Uri value);
+		void SetWebLink(Windows.Foundation.Uri value);
+
+		event Windows.Foundation.TypedEventHandler<DataPackage, ShareCompletedEventArgs> ShareCompleted;
+
+		event Windows.Foundation.TypedEventHandler<DataPackage, Object> ShareCanceled;
 	}
 
 	[contract(ClipboardContract, 1.0)]
@@ -729,7 +709,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 	runtimeclass OperationCompletedEventArgs
 	{
 		DataPackageOperation Operation { get; };
-		
+
 		String AcceptedFormatId { get; };
 	}
 

--- a/specs/clipboard-api/clipboard.idl
+++ b/specs/clipboard-api/clipboard.idl
@@ -71,10 +71,6 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 	interface IDataPackagePropertySetView3;
 	interface IDataPackagePropertySetView4;
 	interface IDataPackagePropertySetView5;
-	interface IDataPackageView;
-	interface IDataPackageView2;
-	interface IDataPackageView3;
-	interface IDataPackageView4;
 	interface IDataProviderDeferral;
 	interface IDataProviderRequest;
 	interface IDataRequest;
@@ -299,54 +295,6 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 	interface IDataPackagePropertySetView5 : IInspectable
 	{
 		[propget] HRESULT IsFromRoamingClipboard([out] [retval] boolean* value);
-	}
-
-	[contract(ClipboardContract, 1.0)]
-	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataPackageView)]
-	[uuid(659f7a31-3335-4e57-b373-8898ffae5ab1)]
-	interface IDataPackageView : IInspectable
-	{
-		[propget] HRESULT Properties([out] [retval] Microsoft.ProjectReunion.ApplicationModel.DataPackagePropertySetView** value);
-		[propget] HRESULT RequestedOperation([out] [retval] Microsoft.ProjectReunion.ApplicationModel.DataPackageOperation* value);
-		HRESULT ReportOperationCompleted([in] Microsoft.ProjectReunion.ApplicationModel.DataPackageOperation value);
-		[propget] HRESULT AvailableFormats([out] [retval] Windows.Foundation.Collections.IVectorView<HSTRING>** formatIds);
-		HRESULT Contains([in] HSTRING formatId, [out] [retval] boolean* value);
-		HRESULT GetDataAsync([in] HSTRING formatId, [out] [retval] Windows.Foundation.IAsyncOperation<IInspectable*>** operation);
-		[overload("GetTextAsync")] HRESULT GetTextAsync([out] [retval] Windows.Foundation.IAsyncOperation<HSTRING>** operation);
-		[overload("GetTextAsync")] HRESULT GetCustomTextAsync([in] HSTRING formatId, [out] [retval] Windows.Foundation.IAsyncOperation<HSTRING>** operation);
-		[deprecated("GetUriAsync may be altered or unavailable for releases after Windows 8.1. Instead, use GetWebLinkAsync or GetApplicationLinkAsync.", deprecate, ClipboardContract, 1.0)] HRESULT GetUriAsync([out] [retval] Windows.Foundation.IAsyncOperation<Windows.Foundation.Uri*>** operation);
-		HRESULT GetHtmlFormatAsync([out] [retval] Windows.Foundation.IAsyncOperation<HSTRING>** operation);
-		HRESULT GetResourceMapAsync([out] [retval] Windows.Foundation.IAsyncOperation<Windows.Foundation.Collections.IMapView<HSTRING, Windows.Storage.Streams.RandomAccessStreamReference*>*>** operation);
-		HRESULT GetRtfAsync([out] [retval] Windows.Foundation.IAsyncOperation<HSTRING>** operation);
-		HRESULT GetBitmapAsync([out] [retval] Windows.Foundation.IAsyncOperation<Windows.Storage.Streams.RandomAccessStreamReference*>** operation);
-		HRESULT GetStorageItemsAsync([out] [retval] Windows.Foundation.IAsyncOperation<Windows.Foundation.Collections.IVectorView<Windows.Storage.IStorageItem*>*>** operation);
-	}
-
-	[contract(ClipboardContract, 1.0)]
-	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataPackageView)]
-	[uuid(a64648c4-fefb-48b4-a0b4-d9be5ac8233b)]
-	interface IDataPackageView2 : IInspectable
-	{
-		HRESULT GetApplicationLinkAsync([out] [retval] Windows.Foundation.IAsyncOperation<Windows.Foundation.Uri*>** operation);
-		HRESULT GetWebLinkAsync([out] [retval] Windows.Foundation.IAsyncOperation<Windows.Foundation.Uri*>** operation);
-	}
-
-	[contract(ClipboardContract, 1.0)]
-	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataPackageView)]
-	[uuid(9b0e47cd-8eef-485d-bdd1-d371e9cf2ebe)]
-	interface IDataPackageView3 : IInspectable
-	{
-		[overload("RequestAccessAsync")] HRESULT RequestAccessAsync([out] [retval] Windows.Foundation.IAsyncOperation<Windows.Security.EnterpriseData.ProtectionPolicyEvaluationResult>** operation);
-		[overload("RequestAccessAsync")] HRESULT RequestAccessWithEnterpriseIdAsync([in] HSTRING enterpriseId, [out] [retval] Windows.Foundation.IAsyncOperation<Windows.Security.EnterpriseData.ProtectionPolicyEvaluationResult>** operation);
-		HRESULT UnlockAndAssumeEnterpriseIdentity([out] [retval] Windows.Security.EnterpriseData.ProtectionPolicyEvaluationResult* result);
-	}
-
-	[contract(ClipboardContract, 2.0)]
-	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataPackageView)]
-	[uuid(a56c7b9b-7865-4177-abf5-99412eb412a9)]
-	interface IDataPackageView4 : IInspectable
-	{
-		HRESULT SetAcceptedFormatId([in] HSTRING formatId);
 	}
 
 	[contract(ClipboardContract, 1.0)]
@@ -593,7 +541,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 		void SetData(String formatId, [hasvariant] Object value);
 		void SetDataProvider(String formatId, DataProviderHandler delayRenderer);
 		void SetText(String value);
-		[deprecated("SetUri may be altered or unavailable in later releases. Instead, use SetWebLink or SetApplicationLink.", deprecate, ClipboardContract, 10.0)]
+		[deprecated("SetUri may be altered or unavailable in future releases. Instead, use SetWebLink or SetApplicationLink.", deprecate, ClipboardContract, 10.0)]
 		void SetUri(Windows.Foundation.Uri value);
 		void SetHtmlFormat(String value);
 
@@ -640,14 +588,43 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 		interface Windows.Foundation.Collections.IIterable<Windows.Foundation.Collections.IKeyValuePair<HSTRING, IInspectable*>*>;
 	}
 
-	[contract(ClipboardContract, 1.0)]
-	[marshaling_behavior(agile)]
+	[contract(ClipboardContract, 2.0)]
+	[interface_name("Microsoft.ProjectReunion.ApplicationModel.IDataPackageView", 659f7a31-3335-4e57-b373-8898ffae5ab1)]
 	runtimeclass DataPackageView
 	{
-		[default] interface Microsoft.ProjectReunion.ApplicationModel.IDataPackageView;
-		[contract(ClipboardContract, 1.0)] interface Microsoft.ProjectReunion.ApplicationModel.IDataPackageView2;
-		[contract(ClipboardContract, 1.0)] interface Microsoft.ProjectReunion.ApplicationModel.IDataPackageView3;
-		[contract(ClipboardContract, 2.0)] interface Microsoft.ProjectReunion.ApplicationModel.IDataPackageView4;
+		DataPackagePropertySetView Properties { get; };
+
+		DataPackageOperation RequestedOperation { get; };
+		void ReportOperationCompleted(DataPackageOperation operation);
+
+		Windows.Foundation.Collections.IVectorView<String> AvailableFormats { get; };
+		Boolean Contains(String formatId);
+
+		Windows.Foundation.IAsyncOperation<Object> GetDataAsync(String formatId);
+
+		[method_name("GetTextAsync")]
+		Windows.Foundation.IAsyncOperation<String> GetTextAsync();
+		[method_name("GetCustomTextAsync")]
+		Windows.Foundation.IAsyncOperation<String> GetTextAsync(String formatId);
+
+		[deprecated("GetUriAsync may be altered or unavailable in future releases. Instead, use GetWebLinkAsync or GetApplicationLinkAsync.", deprecate, ClipboardContract, 2.0)]
+		Windows.Foundation.IAsyncOperation<Windows.Foundation.Uri> GetUriAsync();
+		Windows.Foundation.IAsyncOperation<String> GetHtmlFormatAsync();
+		Windows.Foundation.IAsyncOperation<Windows.Foundation.Collections.IMapView<String, Windows.Storage.Streams.RandomAccessStreamReference> > GetResourceMapAsync();
+		Windows.Foundation.IAsyncOperation<String> GetRtfAsync();
+		Windows.Foundation.IAsyncOperation<Windows.Storage.Streams.RandomAccessStreamReference> GetBitmapAsync();
+		Windows.Foundation.IAsyncOperation<Windows.Foundation.Collections.IVectorView<Windows.Storage.IStorageItem> > GetStorageItemsAsync();
+
+		Windows.Foundation.IAsyncOperation<Windows.Foundation.Uri> GetApplicationLinkAsync();
+		Windows.Foundation.IAsyncOperation<Windows.Foundation.Uri> GetWebLinkAsync();
+
+		[method_name("RequestAccessAsync")]
+		Windows.Foundation.IAsyncOperation<Windows.Security.EnterpriseData.ProtectionPolicyEvaluationResult> RequestAccessAsync();
+		[method_name("RequestAccessWithEnterpriseIdAsync")]
+		Windows.Foundation.IAsyncOperation<Windows.Security.EnterpriseData.ProtectionPolicyEvaluationResult> RequestAccessAsync(String enterpriseId);
+		Windows.Security.EnterpriseData.ProtectionPolicyEvaluationResult UnlockAndAssumeEnterpriseIdentity();
+
+		void SetAcceptedFormatId(String formatId);
 	}
 
 	[contract(ClipboardContract, 1.0)]
@@ -772,7 +749,7 @@ namespace Microsoft.ProjectReunion.ApplicationModel
 	static runtimeclass StandardDataFormats
 	{
 		static String Text { get; };
-		[deprecated("Uri may be altered or unavailable in later releases. Instead, use WebLink or ApplicationLink.", deprecate, ClipboardContract, 6.0)]
+		[deprecated("Uri may be altered or unavailable in future releases. Instead, use WebLink or ApplicationLink.", deprecate, ClipboardContract, 6.0)]
 		static String Uri { get; };
 		static String Html { get; };
 		static String Rtf { get; };

--- a/specs/clipboard-api/clipboard.idl
+++ b/specs/clipboard-api/clipboard.idl
@@ -1,0 +1,925 @@
+// Copyright (c) Microsoft Corp. Licensed under the MIT license.
+
+import "inspectable.idl";
+import "AsyncInfo.idl";
+import "EventToken.idl";
+import "windowscontracts.idl";
+import "Windows.Foundation.idl";
+import "Windows.Security.EnterpriseData.idl";
+import "Windows.Storage.idl";
+import "Windows.Storage.Streams.idl";
+import "Windows.UI.idl";
+
+// Forward Declare
+namespace Windows.Foundation
+{
+	typedef struct DateTime DateTime;
+	runtimeclass Deferral;
+	typedef struct Rect Rect;
+	apicontract UniversalApiContract;
+	runtimeclass Uri;
+}
+
+namespace Windows.Security.EnterpriseData
+{
+	typedef enum ProtectionPolicyEvaluationResult ProtectionPolicyEvaluationResult;
+}
+
+namespace Windows.Storage
+{
+	interface IStorageFile;
+	interface IStorageItem;
+	runtimeclass StorageFile;
+}
+
+namespace Windows.Storage.Streams
+{
+	interface IRandomAccessStreamReference;
+	runtimeclass RandomAccessStreamReference;
+}
+
+namespace Windows.UI
+{
+	typedef struct Color Color;
+}
+
+namespace Microsoft.ProjectReunion.ApplicationModel
+{
+	typedef enum ClipboardHistoryItemsResultStatus ClipboardHistoryItemsResultStatus;
+	typedef enum DataPackageOperation DataPackageOperation;
+	typedef enum SetHistoryItemAsContentStatus SetHistoryItemAsContentStatus;
+	typedef enum ShareUITheme ShareUITheme;
+	delegate DataProviderHandler;
+	delegate ShareProviderHandler;
+	interface IClipboardContentOptions;
+	interface IClipboardHistoryChangedEventArgs;
+	interface IClipboardHistoryItem;
+	interface IClipboardHistoryItemsResult;
+	interface IClipboardStatics;
+	interface IClipboardStatics2;
+	interface IDataPackage;
+	interface IDataPackage2;
+	interface IDataPackage3;
+	interface IDataPackage4;
+	interface IDataPackagePropertySet;
+	interface IDataPackagePropertySet2;
+	interface IDataPackagePropertySet3;
+	interface IDataPackagePropertySet4;
+	interface IDataPackagePropertySetView;
+	interface IDataPackagePropertySetView2;
+	interface IDataPackagePropertySetView3;
+	interface IDataPackagePropertySetView4;
+	interface IDataPackagePropertySetView5;
+	interface IDataPackageView;
+	interface IDataPackageView2;
+	interface IDataPackageView3;
+	interface IDataPackageView4;
+	interface IDataProviderDeferral;
+	interface IDataProviderRequest;
+	interface IDataRequest;
+	interface IDataRequestDeferral;
+	interface IDataRequestedEventArgs;
+	interface IDataTransferManager;
+	interface IDataTransferManager2;
+	interface IDataTransferManagerStatics;
+	interface IDataTransferManagerStatics2;
+	interface IDataTransferManagerStatics3;
+	interface IHtmlFormatHelperStatics;
+	interface IOperationCompletedEventArgs;
+	interface IOperationCompletedEventArgs2;
+	interface IShareCompletedEventArgs;
+	interface IShareProvider;
+	interface IShareProviderFactory;
+	interface IShareProviderOperation;
+	interface IShareProvidersRequestedEventArgs;
+	interface IShareTargetInfo;
+	interface IShareUIOptions;
+	interface ISharedStorageAccessManagerStatics;
+	interface IStandardDataFormatsStatics;
+	interface IStandardDataFormatsStatics2;
+	interface IStandardDataFormatsStatics3;
+	interface ITargetApplicationChosenEventArgs;
+	runtimeclass Clipboard;
+	runtimeclass ClipboardContentOptions;
+	runtimeclass ClipboardHistoryChangedEventArgs;
+	runtimeclass ClipboardHistoryItem;
+	runtimeclass ClipboardHistoryItemsResult;
+	runtimeclass DataPackage;
+	runtimeclass DataPackagePropertySet;
+	runtimeclass DataPackagePropertySetView;
+	runtimeclass DataPackageView;
+	runtimeclass DataProviderDeferral;
+	runtimeclass DataProviderRequest;
+	runtimeclass DataRequest;
+	runtimeclass DataRequestDeferral;
+	runtimeclass DataRequestedEventArgs;
+	runtimeclass DataTransferManager;
+	runtimeclass HtmlFormatHelper;
+	runtimeclass OperationCompletedEventArgs;
+	runtimeclass ShareCompletedEventArgs;
+	runtimeclass ShareProvider;
+	runtimeclass ShareProviderOperation;
+	runtimeclass ShareProvidersRequestedEventArgs;
+	runtimeclass ShareTargetInfo;
+	runtimeclass ShareUIOptions;
+	runtimeclass SharedStorageAccessManager;
+	runtimeclass StandardDataFormats;
+	runtimeclass TargetApplicationChosenEventArgs;
+}
+
+// Generic instantiations
+namespace Microsoft.ProjectReunion.ApplicationModel
+{
+	declare
+	{
+		interface Windows.Foundation.Collections.IIterable<Microsoft.ProjectReunion.ApplicationModel.ClipboardHistoryItem*>;
+		interface Windows.Foundation.Collections.IIterable<Microsoft.ProjectReunion.ApplicationModel.ShareProvider*>;
+		interface Windows.Foundation.Collections.IIterator<Microsoft.ProjectReunion.ApplicationModel.ClipboardHistoryItem*>;
+		interface Windows.Foundation.Collections.IIterator<Microsoft.ProjectReunion.ApplicationModel.ShareProvider*>;
+		interface Windows.Foundation.Collections.IVectorView<Microsoft.ProjectReunion.ApplicationModel.ClipboardHistoryItem*>;
+		interface Windows.Foundation.Collections.IVectorView<Microsoft.ProjectReunion.ApplicationModel.ShareProvider*>;
+		interface Windows.Foundation.Collections.IVector<Microsoft.ProjectReunion.ApplicationModel.ShareProvider*>;
+		interface Windows.Foundation.EventHandler<Microsoft.ProjectReunion.ApplicationModel.ClipboardHistoryChangedEventArgs*>;
+		interface Windows.Foundation.IAsyncOperation<Microsoft.ProjectReunion.ApplicationModel.ClipboardHistoryItemsResult*>;
+		interface Windows.Foundation.IAsyncOperation<Microsoft.ProjectReunion.ApplicationModel.DataPackage*>;
+		interface Windows.Foundation.IAsyncOperation<Microsoft.ProjectReunion.ApplicationModel.DataPackageOperation>;
+		interface Windows.Foundation.TypedEventHandler<Microsoft.ProjectReunion.ApplicationModel.DataPackage*, IInspectable*>;
+		interface Windows.Foundation.TypedEventHandler<Microsoft.ProjectReunion.ApplicationModel.DataPackage*, Microsoft.ProjectReunion.ApplicationModel.OperationCompletedEventArgs*>;
+		interface Windows.Foundation.TypedEventHandler<Microsoft.ProjectReunion.ApplicationModel.DataPackage*, Microsoft.ProjectReunion.ApplicationModel.ShareCompletedEventArgs*>;
+		interface Windows.Foundation.TypedEventHandler<Microsoft.ProjectReunion.ApplicationModel.DataTransferManager*, Microsoft.ProjectReunion.ApplicationModel.DataRequestedEventArgs*>;
+		interface Windows.Foundation.TypedEventHandler<Microsoft.ProjectReunion.ApplicationModel.DataTransferManager*, Microsoft.ProjectReunion.ApplicationModel.ShareProvidersRequestedEventArgs*>;
+		interface Windows.Foundation.TypedEventHandler<Microsoft.ProjectReunion.ApplicationModel.DataTransferManager*, Microsoft.ProjectReunion.ApplicationModel.TargetApplicationChosenEventArgs*>;
+	}
+}
+
+// Type definition
+namespace Microsoft.ProjectReunion.ApplicationModel
+{
+	[contract(Windows.Foundation.UniversalApiContract, 7.0)]
+	enum ClipboardHistoryItemsResultStatus
+	{
+		Success					 = 0,
+		AccessDenied			 = 1,
+		ClipboardHistoryDisabled = 2
+	};
+
+	[contract(Windows.Foundation.UniversalApiContract, 1.0)]
+	[flags]
+	enum DataPackageOperation
+	{
+		None = 0x0,
+		Copy = 0x1,
+		Move = 0x2,
+		Link = 0x4
+	};
+
+	[contract(Windows.Foundation.UniversalApiContract, 7.0)]
+	enum SetHistoryItemAsContentStatus
+	{
+		Success		 = 0,
+		AccessDenied = 1,
+		ItemDeleted	 = 2
+	};
+
+	[contract(Windows.Foundation.UniversalApiContract, 5.0)]
+	enum ShareUITheme
+	{
+		Default = 0,
+		Light	= 1,
+		Dark	= 2
+	};
+
+	[contract(Windows.Foundation.UniversalApiContract, 1.0)]
+	[uuid(E7ECD720-F2F4-4A2D-920E-170A2F482A27)]
+	delegate
+		HRESULT DataProviderHandler([in] Microsoft.ProjectReunion.ApplicationModel.DataProviderRequest* request);
+
+	[contract(Windows.Foundation.UniversalApiContract, 4.0)]
+	[uuid(E7F9D9BA-E1BA-4E4D-BD65-D43845D3212F)]
+	delegate
+		HRESULT ShareProviderHandler([in] Microsoft.ProjectReunion.ApplicationModel.ShareProviderOperation* operation);
+
+	[contract(Windows.Foundation.UniversalApiContract, 7.0)]
+	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.ClipboardContentOptions)]
+	[uuid(E888A98C-AD4B-5447-A056-AB3556276D2B)]
+	interface IClipboardContentOptions : IInspectable
+	{
+		[propget] HRESULT IsRoamable([out] [retval] boolean* value);
+		[propput] HRESULT IsRoamable([in] boolean value);
+		[propget] HRESULT IsAllowedInHistory([out] [retval] boolean* value);
+		[propput] HRESULT IsAllowedInHistory([in] boolean value);
+		[propget] HRESULT RoamingFormats([out] [retval] Windows.Foundation.Collections.IVector<HSTRING>** value);
+		[propget] HRESULT HistoryFormats([out] [retval] Windows.Foundation.Collections.IVector<HSTRING>** value);
+	}
+
+	[contract(Windows.Foundation.UniversalApiContract, 7.0)]
+	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.ClipboardHistoryChangedEventArgs)]
+	[uuid(C0BE453F-8EA2-53CE-9ABA-8D2212573452)]
+	interface IClipboardHistoryChangedEventArgs : IInspectable
+	{
+	}
+
+	[contract(Windows.Foundation.UniversalApiContract, 7.0)]
+	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.ClipboardHistoryItem)]
+	[uuid(0173BD8A-AFFF-5C50-AB92-3D19F481EC58)]
+	interface IClipboardHistoryItem : IInspectable
+	{
+		[propget] HRESULT Id([out] [retval] HSTRING* value);
+		[propget] HRESULT Timestamp([out] [retval] Windows.Foundation.DateTime* value);
+		[propget] HRESULT Content([out] [retval] Microsoft.ProjectReunion.ApplicationModel.DataPackageView** value);
+	}
+
+	[contract(Windows.Foundation.UniversalApiContract, 7.0)]
+	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.ClipboardHistoryItemsResult)]
+	[uuid(E6DFDEE6-0EE2-52E3-852B-F295DB65939A)]
+	interface IClipboardHistoryItemsResult : IInspectable
+	{
+		[propget] HRESULT Status([out] [retval] Microsoft.ProjectReunion.ApplicationModel.ClipboardHistoryItemsResultStatus* value);
+		[propget] HRESULT Items([out] [retval] Windows.Foundation.Collections.IVectorView<Microsoft.ProjectReunion.ApplicationModel.ClipboardHistoryItem*>** value);
+	}
+
+	[contract(Windows.Foundation.UniversalApiContract, 1.0)]
+	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.Clipboard)]
+	[uuid(C627E291-34E2-4963-8EED-93CBB0EA3D70)]
+	interface IClipboardStatics : IInspectable
+	{
+		HRESULT GetContent([out] [retval] Microsoft.ProjectReunion.ApplicationModel.DataPackageView** result);
+		HRESULT SetContent([in] Microsoft.ProjectReunion.ApplicationModel.DataPackage* content);
+		HRESULT Flush();
+		HRESULT Clear();
+		[eventadd] HRESULT ContentChanged([in] Windows.Foundation.EventHandler<IInspectable*>* handler, [out] [retval] EventRegistrationToken* token);
+		[eventremove] HRESULT ContentChanged([in] EventRegistrationToken token);
+	}
+
+	[contract(Windows.Foundation.UniversalApiContract, 7.0)]
+	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.Clipboard)]
+	[uuid(D2AC1B6A-D29F-554B-B303-F0452345FE02)]
+	interface IClipboardStatics2 : IInspectable
+	{
+		HRESULT GetHistoryItemsAsync([out] [retval] Windows.Foundation.IAsyncOperation<Microsoft.ProjectReunion.ApplicationModel.ClipboardHistoryItemsResult*>** operation);
+		HRESULT ClearHistory([out] [retval] boolean* result);
+		HRESULT DeleteItemFromHistory([in] Microsoft.ProjectReunion.ApplicationModel.ClipboardHistoryItem* item, [out] [retval] boolean* result);
+		HRESULT SetHistoryItemAsContent([in] Microsoft.ProjectReunion.ApplicationModel.ClipboardHistoryItem* item, [out] [retval] Microsoft.ProjectReunion.ApplicationModel.SetHistoryItemAsContentStatus* result);
+		HRESULT IsHistoryEnabled([out] [retval] boolean* result);
+		HRESULT IsRoamingEnabled([out] [retval] boolean* result);
+		HRESULT SetContentWithOptions([in] Microsoft.ProjectReunion.ApplicationModel.DataPackage* content, [in] Microsoft.ProjectReunion.ApplicationModel.ClipboardContentOptions* options, [out] [retval] boolean* result);
+		[eventadd] HRESULT HistoryChanged([in] Windows.Foundation.EventHandler<Microsoft.ProjectReunion.ApplicationModel.ClipboardHistoryChangedEventArgs*>* handler, [out] [retval] EventRegistrationToken* token);
+		[eventremove] HRESULT HistoryChanged([in] EventRegistrationToken token);
+		[eventadd] HRESULT RoamingEnabledChanged([in] Windows.Foundation.EventHandler<IInspectable*>* handler, [out] [retval] EventRegistrationToken* token);
+		[eventremove] HRESULT RoamingEnabledChanged([in] EventRegistrationToken token);
+		[eventadd] HRESULT HistoryEnabledChanged([in] Windows.Foundation.EventHandler<IInspectable*>* handler, [out] [retval] EventRegistrationToken* token);
+		[eventremove] HRESULT HistoryEnabledChanged([in] EventRegistrationToken token);
+	}
+
+	[contract(Windows.Foundation.UniversalApiContract, 1.0)]
+	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataPackage)]
+	[uuid(61EBF5C7-EFEA-4346-9554-981D7E198FFE)]
+	interface IDataPackage : IInspectable
+	{
+		HRESULT GetView([out] [retval] Microsoft.ProjectReunion.ApplicationModel.DataPackageView** result);
+		[propget] HRESULT Properties([out] [retval] Microsoft.ProjectReunion.ApplicationModel.DataPackagePropertySet** value);
+		[propget] HRESULT RequestedOperation([out] [retval] Microsoft.ProjectReunion.ApplicationModel.DataPackageOperation* value);
+		[propput] HRESULT RequestedOperation([in] Microsoft.ProjectReunion.ApplicationModel.DataPackageOperation value);
+		[eventadd] HRESULT OperationCompleted([in] Windows.Foundation.TypedEventHandler<Microsoft.ProjectReunion.ApplicationModel.DataPackage*, Microsoft.ProjectReunion.ApplicationModel.OperationCompletedEventArgs*>* handler, [out] [retval] EventRegistrationToken* token);
+		[eventremove] HRESULT OperationCompleted([in] EventRegistrationToken token);
+		[eventadd] HRESULT Destroyed([in] Windows.Foundation.TypedEventHandler<Microsoft.ProjectReunion.ApplicationModel.DataPackage*, IInspectable*>* handler, [out] [retval] EventRegistrationToken* token);
+		[eventremove] HRESULT Destroyed([in] EventRegistrationToken token);
+		HRESULT SetData([in] HSTRING formatId, [in] IInspectable* value);
+		HRESULT SetDataProvider([in] HSTRING formatId, [in] Microsoft.ProjectReunion.ApplicationModel.DataProviderHandler* delayRenderer);
+		HRESULT SetText([in] HSTRING value);
+		[deprecated("SetUri may be altered or unavailable for releases after Windows Phone 'OSVersion' (TBD).Instead, use SetWebLink or SetApplicationLink.", deprecate, Windows.Foundation.UniversalApiContract, 1.0)] HRESULT SetUri([in] Windows.Foundation.Uri* value);
+		HRESULT SetHtmlFormat([in] HSTRING value);
+		[propget] HRESULT ResourceMap([out] [retval] Windows.Foundation.Collections.IMap<HSTRING, Windows.Storage.Streams.RandomAccessStreamReference*>** value);
+		HRESULT SetRtf([in] HSTRING value);
+		HRESULT SetBitmap([in] Windows.Storage.Streams.RandomAccessStreamReference* value);
+		[overload("SetStorageItems")] HRESULT SetStorageItemsReadOnly([in] Windows.Foundation.Collections.IIterable<Windows.Storage.IStorageItem*>* value);
+		[overload("SetStorageItems")] HRESULT SetStorageItems([in] Windows.Foundation.Collections.IIterable<Windows.Storage.IStorageItem*>* value, [in] boolean readOnly);
+	}
+
+	[contract(Windows.Foundation.UniversalApiContract, 1.0)]
+	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataPackage)]
+	[uuid(041C1FE9-2409-45E1-A538-4C53EEEE04A7)]
+	interface IDataPackage2 : IInspectable
+	{
+		HRESULT SetApplicationLink([in] Windows.Foundation.Uri* value);
+		HRESULT SetWebLink([in] Windows.Foundation.Uri* value);
+	}
+
+	[contract(Windows.Foundation.UniversalApiContract, 4.0)]
+	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataPackage)]
+	[uuid(88F31F5D-787B-4D32-965A-A9838105A056)]
+	interface IDataPackage3 : IInspectable
+	{
+		[eventadd] HRESULT ShareCompleted([in] Windows.Foundation.TypedEventHandler<Microsoft.ProjectReunion.ApplicationModel.DataPackage*, Microsoft.ProjectReunion.ApplicationModel.ShareCompletedEventArgs*>* handler, [out] [retval] EventRegistrationToken* token);
+		[eventremove] HRESULT ShareCompleted([in] EventRegistrationToken token);
+	}
+
+	[contract(Windows.Foundation.UniversalApiContract, 10.0)]
+	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataPackage)]
+	[uuid(13A24EC8-9382-536F-852A-3045E1B29A3B)]
+	interface IDataPackage4 : IInspectable
+	{
+		[eventadd] HRESULT ShareCanceled([in] Windows.Foundation.TypedEventHandler<Microsoft.ProjectReunion.ApplicationModel.DataPackage*, IInspectable*>* handler, [out] [retval] EventRegistrationToken* token);
+		[eventremove] HRESULT ShareCanceled([in] EventRegistrationToken token);
+	}
+
+	[contract(Windows.Foundation.UniversalApiContract, 1.0)]
+	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataPackagePropertySet)]
+	[uuid(CD1C93EB-4C4C-443A-A8D3-F5C241E91689)]
+	interface IDataPackagePropertySet : IInspectable
+		requires
+			Windows.Foundation.Collections.IMap<HSTRING, IInspectable*>,
+			Windows.Foundation.Collections.IIterable<Windows.Foundation.Collections.IKeyValuePair<HSTRING, IInspectable*>*>
+	{
+		[propget] HRESULT Title([out] [retval] HSTRING* value);
+		[propput] HRESULT Title([in] HSTRING value);
+		[propget] HRESULT Description([out] [retval] HSTRING* value);
+		[propput] HRESULT Description([in] HSTRING value);
+		[propget] HRESULT Thumbnail([out] [retval] Windows.Storage.Streams.IRandomAccessStreamReference** value);
+		[propput] HRESULT Thumbnail([in] Windows.Storage.Streams.IRandomAccessStreamReference* value);
+		[propget] HRESULT FileTypes([out] [retval] Windows.Foundation.Collections.IVector<HSTRING>** value);
+		[propget] HRESULT ApplicationName([out] [retval] HSTRING* value);
+		[propput] HRESULT ApplicationName([in] HSTRING value);
+		[propget] HRESULT ApplicationListingUri([out] [retval] Windows.Foundation.Uri** value);
+		[propput] HRESULT ApplicationListingUri([in] Windows.Foundation.Uri* value);
+	}
+
+	[contract(Windows.Foundation.UniversalApiContract, 1.0)]
+	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataPackagePropertySet)]
+	[uuid(EB505D4A-9800-46AA-B181-7B6F0F2B919A)]
+	interface IDataPackagePropertySet2 : IInspectable
+	{
+		[propget] HRESULT ContentSourceWebLink([out] [retval] Windows.Foundation.Uri** value);
+		[propput] HRESULT ContentSourceWebLink([in] Windows.Foundation.Uri* value);
+		[propget] HRESULT ContentSourceApplicationLink([out] [retval] Windows.Foundation.Uri** value);
+		[propput] HRESULT ContentSourceApplicationLink([in] Windows.Foundation.Uri* value);
+		[propget] HRESULT PackageFamilyName([out] [retval] HSTRING* value);
+		[propput] HRESULT PackageFamilyName([in] HSTRING value);
+		[propget] HRESULT Square30x30Logo([out] [retval] Windows.Storage.Streams.IRandomAccessStreamReference** value);
+		[propput] HRESULT Square30x30Logo([in] Windows.Storage.Streams.IRandomAccessStreamReference* value);
+		[propget] HRESULT LogoBackgroundColor([out] [retval] Windows.UI.Color* value);
+		[propput] HRESULT LogoBackgroundColor([in] Windows.UI.Color value);
+	}
+
+	[contract(Windows.Foundation.UniversalApiContract, 1.0)]
+	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataPackagePropertySet)]
+	[uuid(9E87FD9B-5205-401B-874A-455653BD39E8)]
+	interface IDataPackagePropertySet3 : IInspectable
+	{
+		[propget] HRESULT EnterpriseId([out] [retval] HSTRING* value);
+		[propput] HRESULT EnterpriseId([in] HSTRING value);
+	}
+
+	[contract(Windows.Foundation.UniversalApiContract, 6.0)]
+	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataPackagePropertySet)]
+	[uuid(6390EBF5-1739-4C74-B22F-865FAB5E8545)]
+	interface IDataPackagePropertySet4 : IInspectable
+	{
+		[propget] HRESULT ContentSourceUserActivityJson([out] [retval] HSTRING* value);
+		[propput] HRESULT ContentSourceUserActivityJson([in] HSTRING value);
+	}
+
+	[contract(Windows.Foundation.UniversalApiContract, 1.0)]
+	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataPackagePropertySetView)]
+	[uuid(B94CEC01-0C1A-4C57-BE55-75D01289735D)]
+	interface IDataPackagePropertySetView : IInspectable
+	{
+		[propget] HRESULT Title([out] [retval] HSTRING* value);
+		[propget] HRESULT Description([out] [retval] HSTRING* value);
+		[propget] HRESULT Thumbnail([out] [retval] Windows.Storage.Streams.RandomAccessStreamReference** value);
+		[propget] HRESULT FileTypes([out] [retval] Windows.Foundation.Collections.IVectorView<HSTRING>** value);
+		[propget] HRESULT ApplicationName([out] [retval] HSTRING* value);
+		[propget] HRESULT ApplicationListingUri([out] [retval] Windows.Foundation.Uri** value);
+	}
+
+	[contract(Windows.Foundation.UniversalApiContract, 1.0)]
+	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataPackagePropertySetView)]
+	[uuid(6054509B-8EBE-4FEB-9C1E-75E69DE54B84)]
+	interface IDataPackagePropertySetView2 : IInspectable
+	{
+		[propget] HRESULT PackageFamilyName([out] [retval] HSTRING* value);
+		[propget] HRESULT ContentSourceWebLink([out] [retval] Windows.Foundation.Uri** value);
+		[propget] HRESULT ContentSourceApplicationLink([out] [retval] Windows.Foundation.Uri** value);
+		[propget] HRESULT Square30x30Logo([out] [retval] Windows.Storage.Streams.IRandomAccessStreamReference** value);
+		[propget] HRESULT LogoBackgroundColor([out] [retval] Windows.UI.Color* value);
+	}
+
+	[contract(Windows.Foundation.UniversalApiContract, 1.0)]
+	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataPackagePropertySetView)]
+	[uuid(DB764CE5-D174-495C-84FC-1A51F6AB45D7)]
+	interface IDataPackagePropertySetView3 : IInspectable
+	{
+		[propget] HRESULT EnterpriseId([out] [retval] HSTRING* value);
+	}
+
+	[contract(Windows.Foundation.UniversalApiContract, 6.0)]
+	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataPackagePropertySetView)]
+	[uuid(4474C80D-D16F-40AE-9580-6F8562B94235)]
+	interface IDataPackagePropertySetView4 : IInspectable
+	{
+		[propget] HRESULT ContentSourceUserActivityJson([out] [retval] HSTRING* value);
+	}
+
+	[contract(Windows.Foundation.UniversalApiContract, 7.0)]
+	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataPackagePropertySetView)]
+	[uuid(6F0A9445-3760-50BB-8523-C4202DED7D78)]
+	interface IDataPackagePropertySetView5 : IInspectable
+	{
+		[propget] HRESULT IsFromRoamingClipboard([out] [retval] boolean* value);
+	}
+
+	[contract(Windows.Foundation.UniversalApiContract, 1.0)]
+	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataPackageView)]
+	[uuid(7B840471-5900-4D85-A90B-10CB85FE3552)]
+	interface IDataPackageView : IInspectable
+	{
+		[propget] HRESULT Properties([out] [retval] Microsoft.ProjectReunion.ApplicationModel.DataPackagePropertySetView** value);
+		[propget] HRESULT RequestedOperation([out] [retval] Microsoft.ProjectReunion.ApplicationModel.DataPackageOperation* value);
+		HRESULT ReportOperationCompleted([in] Microsoft.ProjectReunion.ApplicationModel.DataPackageOperation value);
+		[propget] HRESULT AvailableFormats([out] [retval] Windows.Foundation.Collections.IVectorView<HSTRING>** formatIds);
+		HRESULT Contains([in] HSTRING formatId, [out] [retval] boolean* value);
+		HRESULT GetDataAsync([in] HSTRING formatId, [out] [retval] Windows.Foundation.IAsyncOperation<IInspectable*>** operation);
+		[overload("GetTextAsync")] HRESULT GetTextAsync([out] [retval] Windows.Foundation.IAsyncOperation<HSTRING>** operation);
+		[overload("GetTextAsync")] HRESULT GetCustomTextAsync([in] HSTRING formatId, [out] [retval] Windows.Foundation.IAsyncOperation<HSTRING>** operation);
+		[deprecated("GetUriAsync may be altered or unavailable for releases after Windows 8.1. Instead, use GetWebLinkAsync or GetApplicationLinkAsync.", deprecate, Windows.Foundation.UniversalApiContract, 1.0)] HRESULT GetUriAsync([out] [retval] Windows.Foundation.IAsyncOperation<Windows.Foundation.Uri*>** operation);
+		HRESULT GetHtmlFormatAsync([out] [retval] Windows.Foundation.IAsyncOperation<HSTRING>** operation);
+		HRESULT GetResourceMapAsync([out] [retval] Windows.Foundation.IAsyncOperation<Windows.Foundation.Collections.IMapView<HSTRING, Windows.Storage.Streams.RandomAccessStreamReference*>*>** operation);
+		HRESULT GetRtfAsync([out] [retval] Windows.Foundation.IAsyncOperation<HSTRING>** operation);
+		HRESULT GetBitmapAsync([out] [retval] Windows.Foundation.IAsyncOperation<Windows.Storage.Streams.RandomAccessStreamReference*>** operation);
+		HRESULT GetStorageItemsAsync([out] [retval] Windows.Foundation.IAsyncOperation<Windows.Foundation.Collections.IVectorView<Windows.Storage.IStorageItem*>*>** operation);
+	}
+
+	[contract(Windows.Foundation.UniversalApiContract, 1.0)]
+	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataPackageView)]
+	[uuid(40ECBA95-2450-4C1D-B6B4-ED45463DEE9C)]
+	interface IDataPackageView2 : IInspectable
+	{
+		HRESULT GetApplicationLinkAsync([out] [retval] Windows.Foundation.IAsyncOperation<Windows.Foundation.Uri*>** operation);
+		HRESULT GetWebLinkAsync([out] [retval] Windows.Foundation.IAsyncOperation<Windows.Foundation.Uri*>** operation);
+	}
+
+	[contract(Windows.Foundation.UniversalApiContract, 1.0)]
+	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataPackageView)]
+	[uuid(D37771A8-DDAD-4288-8428-D1CAE394128B)]
+	interface IDataPackageView3 : IInspectable
+	{
+		[overload("RequestAccessAsync")] HRESULT RequestAccessAsync([out] [retval] Windows.Foundation.IAsyncOperation<Windows.Security.EnterpriseData.ProtectionPolicyEvaluationResult>** operation);
+		[overload("RequestAccessAsync")] HRESULT RequestAccessWithEnterpriseIdAsync([in] HSTRING enterpriseId, [out] [retval] Windows.Foundation.IAsyncOperation<Windows.Security.EnterpriseData.ProtectionPolicyEvaluationResult>** operation);
+		HRESULT UnlockAndAssumeEnterpriseIdentity([out] [retval] Windows.Security.EnterpriseData.ProtectionPolicyEvaluationResult* result);
+	}
+
+	[contract(Windows.Foundation.UniversalApiContract, 2.0)]
+	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataPackageView)]
+	[uuid(DFE96F1F-E042-4433-A09F-26D6FFDA8B85)]
+	interface IDataPackageView4 : IInspectable
+	{
+		HRESULT SetAcceptedFormatId([in] HSTRING formatId);
+	}
+
+	[contract(Windows.Foundation.UniversalApiContract, 1.0)]
+	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataProviderDeferral)]
+	[uuid(C2CF2373-2D26-43D9-B69D-DCB86D03F6DA)]
+	interface IDataProviderDeferral : IInspectable
+	{
+		HRESULT Complete();
+	}
+
+	[contract(Windows.Foundation.UniversalApiContract, 1.0)]
+	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataProviderRequest)]
+	[uuid(EBBC7157-D3C8-47DA-ACDE-F82388D5F716)]
+	interface IDataProviderRequest : IInspectable
+	{
+		[propget] HRESULT FormatId([out] [retval] HSTRING* value);
+		[propget] HRESULT Deadline([out] [retval] Windows.Foundation.DateTime* value);
+		HRESULT GetDeferral([out] [retval] Microsoft.ProjectReunion.ApplicationModel.DataProviderDeferral** value);
+		HRESULT SetData([in] IInspectable* value);
+	}
+
+	[contract(Windows.Foundation.UniversalApiContract, 1.0)]
+	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataRequest)]
+	[uuid(4341AE3B-FC12-4E53-8C02-AC714C415A27)]
+	interface IDataRequest : IInspectable
+	{
+		[propget] HRESULT Data([out] [retval] Microsoft.ProjectReunion.ApplicationModel.DataPackage** value);
+		[propput] HRESULT Data([in] Microsoft.ProjectReunion.ApplicationModel.DataPackage* value);
+		[propget] HRESULT Deadline([out] [retval] Windows.Foundation.DateTime* value);
+		HRESULT FailWithDisplayText([in] HSTRING value);
+		HRESULT GetDeferral([out] [retval] Microsoft.ProjectReunion.ApplicationModel.DataRequestDeferral** value);
+	}
+
+	[contract(Windows.Foundation.UniversalApiContract, 1.0)]
+	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataRequestDeferral)]
+	[uuid(6DC4B89F-0386-4263-87C1-ED7DCE30890E)]
+	interface IDataRequestDeferral : IInspectable
+	{
+		HRESULT Complete();
+	}
+
+	[contract(Windows.Foundation.UniversalApiContract, 1.0)]
+	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataRequestedEventArgs)]
+	[uuid(CB8BA807-6AC5-43C9-8AC5-9BA232163182)]
+	interface IDataRequestedEventArgs : IInspectable
+	{
+		[propget] HRESULT Request([out] [retval] Microsoft.ProjectReunion.ApplicationModel.DataRequest** value);
+	}
+
+	[contract(Windows.Foundation.UniversalApiContract, 1.0)]
+	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataTransferManager)]
+	[uuid(A5CAEE9B-8708-49D1-8D36-67D25A8DA00C)]
+	interface IDataTransferManager : IInspectable
+	{
+		[eventadd] HRESULT DataRequested([in] Windows.Foundation.TypedEventHandler<Microsoft.ProjectReunion.ApplicationModel.DataTransferManager*, Microsoft.ProjectReunion.ApplicationModel.DataRequestedEventArgs*>* eventHandler, [out] [retval] EventRegistrationToken* eventCookie);
+		[eventremove] HRESULT DataRequested([in] EventRegistrationToken eventCookie);
+		[eventadd] HRESULT TargetApplicationChosen([in] Windows.Foundation.TypedEventHandler<Microsoft.ProjectReunion.ApplicationModel.DataTransferManager*, Microsoft.ProjectReunion.ApplicationModel.TargetApplicationChosenEventArgs*>* eventHandler, [out] [retval] EventRegistrationToken* eventCookie);
+		[eventremove] HRESULT TargetApplicationChosen([in] EventRegistrationToken eventCookie);
+	}
+
+	[contract(Windows.Foundation.UniversalApiContract, 4.0)]
+	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataTransferManager)]
+	[uuid(30AE7D71-8BA8-4C02-8E3F-DDB23B388715)]
+	interface IDataTransferManager2 : IInspectable
+	{
+		[eventadd] HRESULT ShareProvidersRequested([in] Windows.Foundation.TypedEventHandler<Microsoft.ProjectReunion.ApplicationModel.DataTransferManager*, Microsoft.ProjectReunion.ApplicationModel.ShareProvidersRequestedEventArgs*>* handler, [out] [retval] EventRegistrationToken* token);
+		[eventremove] HRESULT ShareProvidersRequested([in] EventRegistrationToken token);
+	}
+
+	[contract(Windows.Foundation.UniversalApiContract, 1.0)]
+	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataTransferManager)]
+	[uuid(A9DA01AA-E00E-4CFE-AA44-2DD932DCA3D8)]
+	interface IDataTransferManagerStatics : IInspectable
+	{
+		HRESULT ShowShareUI();
+		HRESULT GetForCurrentView([out] [retval] Microsoft.ProjectReunion.ApplicationModel.DataTransferManager** value);
+	}
+
+	[contract(Windows.Foundation.UniversalApiContract, 3.0)]
+	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataTransferManager)]
+	[uuid(C54EC2EC-9F97-4D63-9868-395E271AD8F5)]
+	interface IDataTransferManagerStatics2 : IInspectable
+	{
+		HRESULT IsSupported([out] [retval] boolean* value);
+	}
+
+	[contract(Windows.Foundation.UniversalApiContract, 5.0)]
+	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.DataTransferManager)]
+	[uuid(05845473-6C82-4F5C-AC23-62E458361FAC)]
+	interface IDataTransferManagerStatics3 : IInspectable
+	{
+		[overload("ShowShareUI")] HRESULT ShowShareUIWithOptions([in] Microsoft.ProjectReunion.ApplicationModel.ShareUIOptions* options);
+	}
+
+	[contract(Windows.Foundation.UniversalApiContract, 1.0)]
+	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.HtmlFormatHelper)]
+	[uuid(E22E7749-DD70-446F-AEFC-61CEE59F655E)]
+	interface IHtmlFormatHelperStatics : IInspectable
+	{
+		HRESULT GetStaticFragment([in] HSTRING htmlFormat, [out] [retval] HSTRING* htmlFragment);
+		HRESULT CreateHtmlFormat([in] HSTRING htmlFragment, [out] [retval] HSTRING* htmlFormat);
+	}
+
+	[contract(Windows.Foundation.UniversalApiContract, 1.0)]
+	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.OperationCompletedEventArgs)]
+	[uuid(E7AF329D-051D-4FAB-B1A9-47FD77F70A41)]
+	interface IOperationCompletedEventArgs : IInspectable
+	{
+		[propget] HRESULT Operation([out] [retval] Microsoft.ProjectReunion.ApplicationModel.DataPackageOperation* value);
+	}
+
+	[contract(Windows.Foundation.UniversalApiContract, 2.0)]
+	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.OperationCompletedEventArgs)]
+	[uuid(858FA073-1E19-4105-B2F7-C8478808D562)]
+	interface IOperationCompletedEventArgs2 : IInspectable
+	{
+		[propget] HRESULT AcceptedFormatId([out] [retval] HSTRING* value);
+	}
+
+	[contract(Windows.Foundation.UniversalApiContract, 4.0)]
+	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.ShareCompletedEventArgs)]
+	[uuid(4574C442-F913-4F60-9DF7-CC4060AB1916)]
+	interface IShareCompletedEventArgs : IInspectable
+	{
+		[propget] HRESULT ShareTarget([out] [retval] Microsoft.ProjectReunion.ApplicationModel.ShareTargetInfo** value);
+	}
+
+	[contract(Windows.Foundation.UniversalApiContract, 4.0)]
+	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.ShareProvider)]
+	[uuid(2FABE026-443E-4CDA-AF25-8D81070EFD80)]
+	interface IShareProvider : IInspectable
+	{
+		[propget] HRESULT Title([out] [retval] HSTRING* value);
+		[propget] HRESULT DisplayIcon([out] [retval] Windows.Storage.Streams.RandomAccessStreamReference** value);
+		[propget] HRESULT BackgroundColor([out] [retval] Windows.UI.Color* value);
+		[propget] HRESULT Tag([out] [retval] IInspectable** value);
+		[propput] HRESULT Tag([in] IInspectable* value);
+	}
+
+	[contract(Windows.Foundation.UniversalApiContract, 4.0)]
+	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.ShareProvider)]
+	[uuid(172A174C-E79E-4F6D-B07D-128F469E0296)]
+	interface IShareProviderFactory : IInspectable
+	{
+		HRESULT Create([in] HSTRING title, [in] Windows.Storage.Streams.RandomAccessStreamReference* displayIcon, [in] Windows.UI.Color backgroundColor, [in] Microsoft.ProjectReunion.ApplicationModel.ShareProviderHandler* handler, [out] [retval] Microsoft.ProjectReunion.ApplicationModel.ShareProvider** result);
+	}
+
+	[contract(Windows.Foundation.UniversalApiContract, 4.0)]
+	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.ShareProviderOperation)]
+	[uuid(19CEF937-D435-4179-B6AF-14E0492B69F6)]
+	interface IShareProviderOperation : IInspectable
+	{
+		[propget] HRESULT Data([out] [retval] Microsoft.ProjectReunion.ApplicationModel.DataPackageView** value);
+		[propget] HRESULT Provider([out] [retval] Microsoft.ProjectReunion.ApplicationModel.ShareProvider** value);
+		HRESULT ReportCompleted();
+	}
+
+	[contract(Windows.Foundation.UniversalApiContract, 4.0)]
+	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.ShareProvidersRequestedEventArgs)]
+	[uuid(F888F356-A3F8-4FCE-85E4-8826E63BE799)]
+	interface IShareProvidersRequestedEventArgs : IInspectable
+	{
+		[propget] HRESULT Providers([out] [retval] Windows.Foundation.Collections.IVector<Microsoft.ProjectReunion.ApplicationModel.ShareProvider*>** value);
+		[propget] HRESULT Data([out] [retval] Microsoft.ProjectReunion.ApplicationModel.DataPackageView** value);
+		HRESULT GetDeferral([out] [retval] Windows.Foundation.Deferral** value);
+	}
+
+	[contract(Windows.Foundation.UniversalApiContract, 4.0)]
+	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.ShareTargetInfo)]
+	[uuid(385BE607-C6E8-4114-B294-28F3BB6F9904)]
+	interface IShareTargetInfo : IInspectable
+	{
+		[propget] HRESULT AppUserModelId([out] [retval] HSTRING* value);
+		[propget] HRESULT ShareProvider([out] [retval] Microsoft.ProjectReunion.ApplicationModel.ShareProvider** value);
+	}
+
+	[contract(Windows.Foundation.UniversalApiContract, 5.0)]
+	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.ShareUIOptions)]
+	[uuid(72FA8A80-342F-4D90-9551-2AE04E37680C)]
+	interface IShareUIOptions : IInspectable
+	{
+		[propget] HRESULT Theme([out] [retval] Microsoft.ProjectReunion.ApplicationModel.ShareUITheme* value);
+		[propput] HRESULT Theme([in] Microsoft.ProjectReunion.ApplicationModel.ShareUITheme value);
+		[propget] HRESULT SelectionRect([out] [retval] Windows.Foundation.IReference<Windows.Foundation.Rect>** value);
+		[propput] HRESULT SelectionRect([in] Windows.Foundation.IReference<Windows.Foundation.Rect>* value);
+	}
+
+	[contract(Windows.Foundation.UniversalApiContract, 1.0)]
+	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.SharedStorageAccessManager)]
+	[uuid(C6132ADA-34B1-4849-BD5F-D09FEE3158C5)]
+	interface ISharedStorageAccessManagerStatics : IInspectable
+	{
+		HRESULT AddFile([in] Windows.Storage.IStorageFile* file, [out] [retval] HSTRING* outToken);
+		HRESULT RedeemTokenForFileAsync([in] HSTRING token, [out] [retval] Windows.Foundation.IAsyncOperation<Windows.Storage.StorageFile*>** operation);
+		HRESULT RemoveFile([in] HSTRING token);
+	}
+
+	[contract(Windows.Foundation.UniversalApiContract, 1.0)]
+	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.StandardDataFormats)]
+	[uuid(7ED681A1-A880-40C9-B4ED-0BEE1E15F549)]
+	interface IStandardDataFormatsStatics : IInspectable
+	{
+		[propget] HRESULT Text([out] [retval] HSTRING* value);
+		[deprecated("Uri may be altered or unavailable for releases after Windows Phone 'OSVersion' (TBD). Instead, use WebLink or ApplicationLink.", deprecate, Windows.Foundation.UniversalApiContract, 1.0)] [propget] HRESULT Uri([out] [retval] HSTRING* value);
+		[propget] HRESULT Html([out] [retval] HSTRING* value);
+		[propget] HRESULT Rtf([out] [retval] HSTRING* value);
+		[propget] HRESULT Bitmap([out] [retval] HSTRING* value);
+		[propget] HRESULT StorageItems([out] [retval] HSTRING* value);
+	}
+
+	[contract(Windows.Foundation.UniversalApiContract, 1.0)]
+	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.StandardDataFormats)]
+	[uuid(42A254F4-9D76-42E8-861B-47C25DD0CF71)]
+	interface IStandardDataFormatsStatics2 : IInspectable
+	{
+		[propget] HRESULT WebLink([out] [retval] HSTRING* value);
+		[propget] HRESULT ApplicationLink([out] [retval] HSTRING* value);
+	}
+
+	[contract(Windows.Foundation.UniversalApiContract, 6.0)]
+	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.StandardDataFormats)]
+	[uuid(3B57B069-01D4-474C-8B5F-BC8E27F38B21)]
+	interface IStandardDataFormatsStatics3 : IInspectable
+	{
+		[propget] HRESULT UserActivityJsonArray([out] [retval] HSTRING* value);
+	}
+
+	[contract(Windows.Foundation.UniversalApiContract, 1.0)]
+	[exclusiveto(Microsoft.ProjectReunion.ApplicationModel.TargetApplicationChosenEventArgs)]
+	[uuid(CA6FB8AC-2987-4EE3-9C54-D8AFBCB86C1D)]
+	interface ITargetApplicationChosenEventArgs : IInspectable
+	{
+		[propget] HRESULT ApplicationName([out] [retval] HSTRING* value);
+	}
+
+	[contract(Windows.Foundation.UniversalApiContract, 1.0)]
+	[marshaling_behavior(standard)]
+	[static(Microsoft.ProjectReunion.ApplicationModel.IClipboardStatics, Windows.Foundation.UniversalApiContract, 1.0)]
+	[static(Microsoft.ProjectReunion.ApplicationModel.IClipboardStatics2, Windows.Foundation.UniversalApiContract, 7.0)]
+	[threading(both)]
+	runtimeclass Clipboard
+	{
+	}
+
+	[activatable(Windows.Foundation.UniversalApiContract, 7.0)]
+	[contract(Windows.Foundation.UniversalApiContract, 7.0)]
+	[marshaling_behavior(agile)]
+	[threading(both)]
+	runtimeclass ClipboardContentOptions
+	{
+		[default] interface Microsoft.ProjectReunion.ApplicationModel.IClipboardContentOptions;
+	}
+
+	[contract(Windows.Foundation.UniversalApiContract, 7.0)]
+	[marshaling_behavior(agile)]
+	runtimeclass ClipboardHistoryChangedEventArgs
+	{
+		[default] interface Microsoft.ProjectReunion.ApplicationModel.IClipboardHistoryChangedEventArgs;
+	}
+
+	[contract(Windows.Foundation.UniversalApiContract, 7.0)]
+	[marshaling_behavior(agile)]
+	runtimeclass ClipboardHistoryItem
+	{
+		[default] interface Microsoft.ProjectReunion.ApplicationModel.IClipboardHistoryItem;
+	}
+
+	[contract(Windows.Foundation.UniversalApiContract, 7.0)]
+	[marshaling_behavior(agile)]
+	runtimeclass ClipboardHistoryItemsResult
+	{
+		[default] interface Microsoft.ProjectReunion.ApplicationModel.IClipboardHistoryItemsResult;
+	}
+
+	[activatable(Windows.Foundation.UniversalApiContract, 1.0)]
+	[contract(Windows.Foundation.UniversalApiContract, 1.0)]
+	[marshaling_behavior(agile)]
+	[threading(both)]
+	runtimeclass DataPackage
+	{
+		[default] interface Microsoft.ProjectReunion.ApplicationModel.IDataPackage;
+		[contract(Windows.Foundation.UniversalApiContract, 1.0)] interface Microsoft.ProjectReunion.ApplicationModel.IDataPackage2;
+		[contract(Windows.Foundation.UniversalApiContract, 4.0)] interface Microsoft.ProjectReunion.ApplicationModel.IDataPackage3;
+		[contract(Windows.Foundation.UniversalApiContract, 10.0)] interface Microsoft.ProjectReunion.ApplicationModel.IDataPackage4;
+	}
+
+	[contract(Windows.Foundation.UniversalApiContract, 1.0)]
+	[marshaling_behavior(agile)]
+	runtimeclass DataPackagePropertySet
+	{
+		[default] interface Microsoft.ProjectReunion.ApplicationModel.IDataPackagePropertySet;
+		interface Windows.Foundation.Collections.IMap<HSTRING, IInspectable*>;
+		interface Windows.Foundation.Collections.IIterable<Windows.Foundation.Collections.IKeyValuePair<HSTRING, IInspectable*>*>;
+		[contract(Windows.Foundation.UniversalApiContract, 1.0)] interface Microsoft.ProjectReunion.ApplicationModel.IDataPackagePropertySet2;
+		[contract(Windows.Foundation.UniversalApiContract, 1.0)] interface Microsoft.ProjectReunion.ApplicationModel.IDataPackagePropertySet3;
+		[contract(Windows.Foundation.UniversalApiContract, 6.0)] interface Microsoft.ProjectReunion.ApplicationModel.IDataPackagePropertySet4;
+	}
+
+	[contract(Windows.Foundation.UniversalApiContract, 1.0)]
+	[marshaling_behavior(agile)]
+	runtimeclass DataPackagePropertySetView
+	{
+		[default] interface Microsoft.ProjectReunion.ApplicationModel.IDataPackagePropertySetView;
+		[contract(Windows.Foundation.UniversalApiContract, 1.0)] interface Microsoft.ProjectReunion.ApplicationModel.IDataPackagePropertySetView2;
+		[contract(Windows.Foundation.UniversalApiContract, 1.0)] interface Microsoft.ProjectReunion.ApplicationModel.IDataPackagePropertySetView3;
+		[contract(Windows.Foundation.UniversalApiContract, 6.0)] interface Microsoft.ProjectReunion.ApplicationModel.IDataPackagePropertySetView4;
+		[contract(Windows.Foundation.UniversalApiContract, 7.0)] interface Microsoft.ProjectReunion.ApplicationModel.IDataPackagePropertySetView5;
+		interface Windows.Foundation.Collections.IMapView<HSTRING, IInspectable*>;
+		interface Windows.Foundation.Collections.IIterable<Windows.Foundation.Collections.IKeyValuePair<HSTRING, IInspectable*>*>;
+	}
+
+	[contract(Windows.Foundation.UniversalApiContract, 1.0)]
+	[marshaling_behavior(agile)]
+	runtimeclass DataPackageView
+	{
+		[default] interface Microsoft.ProjectReunion.ApplicationModel.IDataPackageView;
+		[contract(Windows.Foundation.UniversalApiContract, 1.0)] interface Microsoft.ProjectReunion.ApplicationModel.IDataPackageView2;
+		[contract(Windows.Foundation.UniversalApiContract, 1.0)] interface Microsoft.ProjectReunion.ApplicationModel.IDataPackageView3;
+		[contract(Windows.Foundation.UniversalApiContract, 2.0)] interface Microsoft.ProjectReunion.ApplicationModel.IDataPackageView4;
+	}
+
+	[contract(Windows.Foundation.UniversalApiContract, 1.0)]
+	[marshaling_behavior(agile)]
+	runtimeclass DataProviderDeferral
+	{
+		[default] interface Microsoft.ProjectReunion.ApplicationModel.IDataProviderDeferral;
+	}
+
+	[contract(Windows.Foundation.UniversalApiContract, 1.0)]
+	[marshaling_behavior(agile)]
+	runtimeclass DataProviderRequest
+	{
+		[default] interface Microsoft.ProjectReunion.ApplicationModel.IDataProviderRequest;
+	}
+
+	[contract(Windows.Foundation.UniversalApiContract, 1.0)]
+	[marshaling_behavior(agile)]
+	runtimeclass DataRequest
+	{
+		[default] interface Microsoft.ProjectReunion.ApplicationModel.IDataRequest;
+	}
+
+	[contract(Windows.Foundation.UniversalApiContract, 1.0)]
+	[marshaling_behavior(agile)]
+	runtimeclass DataRequestDeferral
+	{
+		[default] interface Microsoft.ProjectReunion.ApplicationModel.IDataRequestDeferral;
+	}
+
+	[contract(Windows.Foundation.UniversalApiContract, 1.0)]
+	[marshaling_behavior(agile)]
+	runtimeclass DataRequestedEventArgs
+	{
+		[default] interface Microsoft.ProjectReunion.ApplicationModel.IDataRequestedEventArgs;
+	}
+
+	[contract(Windows.Foundation.UniversalApiContract, 1.0)]
+	[marshaling_behavior(standard)]
+	[static(Microsoft.ProjectReunion.ApplicationModel.IDataTransferManagerStatics, Windows.Foundation.UniversalApiContract, 1.0)]
+	[static(Microsoft.ProjectReunion.ApplicationModel.IDataTransferManagerStatics2, Windows.Foundation.UniversalApiContract, 3.0)]
+	[static(Microsoft.ProjectReunion.ApplicationModel.IDataTransferManagerStatics3, Windows.Foundation.UniversalApiContract, 5.0)]
+	runtimeclass DataTransferManager
+	{
+		[default] interface Microsoft.ProjectReunion.ApplicationModel.IDataTransferManager;
+		[contract(Windows.Foundation.UniversalApiContract, 4.0)] interface Microsoft.ProjectReunion.ApplicationModel.IDataTransferManager2;
+	}
+
+	[contract(Windows.Foundation.UniversalApiContract, 1.0)]
+	[marshaling_behavior(agile)]
+	[static(Microsoft.ProjectReunion.ApplicationModel.IHtmlFormatHelperStatics, Windows.Foundation.UniversalApiContract, 1.0)]
+	runtimeclass HtmlFormatHelper
+	{
+	}
+
+	[contract(Windows.Foundation.UniversalApiContract, 1.0)]
+	[marshaling_behavior(agile)]
+	runtimeclass OperationCompletedEventArgs
+	{
+		[default] interface Microsoft.ProjectReunion.ApplicationModel.IOperationCompletedEventArgs;
+		[contract(Windows.Foundation.UniversalApiContract, 2.0)] interface Microsoft.ProjectReunion.ApplicationModel.IOperationCompletedEventArgs2;
+	}
+
+	[contract(Windows.Foundation.UniversalApiContract, 4.0)]
+	[marshaling_behavior(agile)]
+	runtimeclass ShareCompletedEventArgs
+	{
+		[default] interface Microsoft.ProjectReunion.ApplicationModel.IShareCompletedEventArgs;
+	}
+
+	[activatable(Microsoft.ProjectReunion.ApplicationModel.IShareProviderFactory, Windows.Foundation.UniversalApiContract, 4.0)]
+	[contract(Windows.Foundation.UniversalApiContract, 4.0)]
+	[marshaling_behavior(agile)]
+	runtimeclass ShareProvider
+	{
+		[default] interface Microsoft.ProjectReunion.ApplicationModel.IShareProvider;
+	}
+
+	[contract(Windows.Foundation.UniversalApiContract, 4.0)]
+	[marshaling_behavior(agile)]
+	runtimeclass ShareProviderOperation
+	{
+		[default] interface Microsoft.ProjectReunion.ApplicationModel.IShareProviderOperation;
+	}
+
+	[contract(Windows.Foundation.UniversalApiContract, 4.0)]
+	[marshaling_behavior(agile)]
+	runtimeclass ShareProvidersRequestedEventArgs
+	{
+		[default] interface Microsoft.ProjectReunion.ApplicationModel.IShareProvidersRequestedEventArgs;
+	}
+
+	[contract(Windows.Foundation.UniversalApiContract, 4.0)]
+	[marshaling_behavior(agile)]
+	runtimeclass ShareTargetInfo
+	{
+		[default] interface Microsoft.ProjectReunion.ApplicationModel.IShareTargetInfo;
+	}
+
+	[activatable(Windows.Foundation.UniversalApiContract, 5.0)]
+	[contract(Windows.Foundation.UniversalApiContract, 5.0)]
+	[marshaling_behavior(agile)]
+	[threading(both)]
+	runtimeclass ShareUIOptions
+	{
+		[default] interface Microsoft.ProjectReunion.ApplicationModel.IShareUIOptions;
+	}
+
+	[contract(Windows.Foundation.UniversalApiContract, 1.0)]
+	[static(Microsoft.ProjectReunion.ApplicationModel.ISharedStorageAccessManagerStatics, Windows.Foundation.UniversalApiContract, 1.0)]
+	runtimeclass SharedStorageAccessManager
+	{
+	}
+
+	[contract(Windows.Foundation.UniversalApiContract, 1.0)]
+	[marshaling_behavior(agile)]
+	[static(Microsoft.ProjectReunion.ApplicationModel.IStandardDataFormatsStatics, Windows.Foundation.UniversalApiContract, 1.0)]
+	[static(Microsoft.ProjectReunion.ApplicationModel.IStandardDataFormatsStatics2, Windows.Foundation.UniversalApiContract, 1.0)]
+	[static(Microsoft.ProjectReunion.ApplicationModel.IStandardDataFormatsStatics3, Windows.Foundation.UniversalApiContract, 6.0)]
+	runtimeclass StandardDataFormats
+	{
+	}
+
+	[contract(Windows.Foundation.UniversalApiContract, 1.0)]
+	[marshaling_behavior(agile)]
+	runtimeclass TargetApplicationChosenEventArgs
+	{
+		[default] interface Microsoft.ProjectReunion.ApplicationModel.ITargetApplicationChosenEventArgs;
+	}
+}


### PR DESCRIPTION
This is a API spec proposal for the clipboard API that will be part of the Project Reunion SDK.

The API is exactly the same as UWP Clipboard within [Windows.ApplicationModel.DataTransfer](
https://docs.microsoft.com/uwp/api/windows.applicationmodel.datatransfer), except that:
1. the namespace is different
1. [Clipboard.Flush()](https://docs.microsoft.com/uwp/api/windows.applicationmodel.datatransfer.clipboard.flush?view=winrt-19041) is now completely optional
1. DataPackage's Share-related events are omitted

This API spec is a draft in progress, and is published for the internal review of the clipboard team within Microsoft before more general publication in the main Project Reunion git repo. Folks outside Microsoft are of course welcome to comment as well, but if you do comment as a non-MSFT person, I may not be able to respond to your concern.